### PR TITLE
DIS88 move back & EMU86 cosmetics

### DIFF
--- a/dis88/from_elks/ansi.h
+++ b/dis88/from_elks/ansi.h
@@ -1,0 +1,58 @@
+/* The <ansi.h> header attempts to decide whether the compiler has enough
+ * conformance to Standard C for Minix to take advantage of.  If so, the
+ * symbol _ANSI is defined (as 31415).  Otherwise _ANSI is not defined
+ * here, but it may be defined by applications that want to bend the rules.
+ * The magic number in the definition is to inhibit unnecessary bending
+ * of the rules.  (For consistency with the new '#ifdef _ANSI" tests in
+ * the headers, _ANSI should really be defined as nothing, but that would
+ * break many library routines that use "#if _ANSI".)
+
+ * If _ANSI ends up being defined, a macro
+ *
+ *	_PROTOTYPE(function, params)
+ *
+ * is defined.  This macro expands in different ways, generating either
+ * ANSI Standard C prototypes or old-style K&R (Kernighan & Ritchie)
+ * prototypes, as needed.  Finally, some programs use _CONST, _VOIDSTAR etc
+ * in such a way that they are portable over both ANSI and K&R compilers.
+ * The appropriate macros are defined here.
+ */
+
+#ifndef _ANSI_H
+#define _ANSI_H
+
+#if __STDC__ == 1
+#define _ANSI		31459	/* compiler claims full ANSI conformance */
+#endif
+
+#ifdef __GNUC__
+#define _ANSI		31459	/* gcc conforms enough even in non-ANSI mode */
+#endif
+
+#ifdef _ANSI
+
+/* Keep everything for ANSI prototypes. */
+#define	_PROTOTYPE(function, params)	function params
+#define	_ARGS(params)			params
+
+#define	_VOIDSTAR	void *
+#define	_VOID		void
+#define	_CONST		const
+#define	_VOLATILE	volatile
+#define _SIZET		size_t
+
+#else
+
+/* Throw away the parameters for K&R prototypes. */
+#define	_PROTOTYPE(function, params)	function()
+#define	_ARGS(params)			()
+
+#define	_VOIDSTAR	void *
+#define	_VOID		void
+#define	_CONST
+#define	_VOLATILE
+#define _SIZET		int
+
+#endif
+
+#endif

--- a/dis88/from_elks/dis.h
+++ b/dis88/from_elks/dis.h
@@ -1,0 +1,161 @@
+ /*
+  * ** @(#) dis.h, Ver. 2.1 created 00:00:00 87/09/01
+  */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  *  Copyright (C) 1987 G. M. Harding, all rights reserved  *
+  *                                                         *
+  * Permission to copy and  redistribute is hereby granted, *
+  * provided full source code,  with all copyright notices, *
+  * accompanies any redistribution.                         *
+  *                                                         *
+  * This file contains declarations and definitions used by *
+  * the 8088 disassembler program. The program was designed *
+  * for execution on a machine of its own type (i.e., it is *
+  * not designed as a cross-disassembler);  consequently, A *
+  * SIXTEEN-BIT INTEGER SIZE HAS BEEN ASSUMED. This assump- *
+  * tion is not particularly important,  however, except in *
+  * the machine-specific  portions of the code  (i.e.,  the *
+  * handler  routines and the optab[] array).  It should be *
+  * possible to override this assumption,  for execution on *
+  * 32-bit machines,  by use of a  pre-processor  directive *
+  * (see below); however, this has not been tested.         *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <sys/types.h>
+#include <fcntl.h>		/* System file-control definitions  */
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>		/* System standard I/O definitions  */
+#include "img.h"		/* Object file format definitions   */
+#include "a.out.h"		/* Just so it builds, really :)     */
+#include "ansi.h"
+
+#define MAXSYM  ((sizeof(int)-1)*32400/ \
+                 (sizeof(struct nlist)+sizeof(struct reloc)))
+			/* Maximum entries in symbol table  */
+
+extern struct nlist		/* Array to hold the symbol table   */
+  symtab[MAXSYM];
+
+extern struct reloc		/* Array to hold relocation table   */
+  relo[MAXSYM];
+
+extern int symptr;		/* Index into the symtab[] array    */
+extern int relptr;		/* Index into the relo[] array      */
+
+struct opcode {			/* Format for opcode data records   */
+    char *text;			/* Pointer to mnemonic text   */
+    void (*func) ();		/* Pointer to handler routine */
+    unsigned min;		/* Minimum # of object bytes  */
+    unsigned max;		/* Maximum # of object bytes  */
+};
+
+extern struct opcode		/* Array to hold the opcode table   */
+  optab[256];
+
+extern char *REGS[];		/* Table of register names          */
+extern char *REGS0[];		/* Mode 0 register name table       */
+extern char *REGS1[];		/* Mode 1 register name table       */
+
+#define AL REGS[0]		/* CPU register manifests           */
+#define CL REGS[1]
+#define DL REGS[2]
+#define BL REGS[3]
+#define AH REGS[4]
+#define CH REGS[5]
+#define DH REGS[6]
+#define BH REGS[7]
+#define AX REGS[8]
+#define CX REGS[9]
+#define DX REGS[10]
+#define BX REGS[11]
+#define SP REGS[12]
+#define BP REGS[13]
+#define SI REGS[14]
+#define DI REGS[15]
+#define ES REGS[16]
+#define CS REGS[17]
+#define SS REGS[18]
+#define DS REGS[19]
+#define BX_SI REGS0[0]
+#define BX_DI REGS0[1]
+#define BP_SI REGS0[2]
+#define BP_DI REGS0[3]
+
+extern int symrank[6][6];	/* Symbol type/rank matrix    */
+extern unsigned long PC;	/* Current program counter    */
+extern int segflg;		/* Flag: segment override in effect */
+extern int objflg;		/* Flag: output object as a comment */
+
+#define OBJMAX 8		/* Size of the object code buffer   */
+
+extern unsigned char /* Internal buffer for object code  */ objbuf[OBJMAX];
+
+extern int objptr;		/* Index into the objbuf[] array    */
+
+extern char ADD[],		/* Opcode family mnemonic strings   */
+  OR[],
+    ADC[],
+    SBB[],
+    AND[],
+    SUB[],
+    XOR[], CMP[], NOT[], NEG[], MUL[], DIV[], MOV[], ESC[], TEST[], AMBIG[];
+
+extern char *OPFAM[];		/* Indexed mnemonic family table    */
+extern ImgHeader HDR;		/* Holds the .img file's header   */
+
+#define LOOK_ABS 0		/* Arguments to lookup() function   */
+#define LOOK_REL 1
+#define LOOK_LNG 2
+
+#define TR_STD 0		/* Arguments to mtrans() function   */
+#define TR_SEG 8
+			/* Macro for byte input primitive   */
+/* #define FETCH(p)  ++PC; p = getchar() & 0xff; objbuf[objptr++] = p */
+static int _F_;
+#define FETCH(p)  (p)=_F_ = Fetch(); if (_F_<0) {printf("???\n"); return FRV; }
+#define FRV
+
+/* disfp.c */
+_PROTOTYPE(void eshand, (int j));
+_PROTOTYPE(void fphand, (int j));
+_PROTOTYPE(void inhand, (int j));
+
+/* dishand.c */
+_PROTOTYPE(void objini, (int j));
+_PROTOTYPE(void objout, (void));
+_PROTOTYPE(void badseq, (int j, int k));
+_PROTOTYPE(void dfhand, (int j));
+_PROTOTYPE(void sbhand, (int j));
+_PROTOTYPE(void aohand, (int j));
+_PROTOTYPE(void sjhand, (int j));
+_PROTOTYPE(void imhand, (int j));
+_PROTOTYPE(void mvhand, (int j));
+_PROTOTYPE(void mshand, (int j));
+_PROTOTYPE(void pohand, (int j));
+_PROTOTYPE(void cihand, (int j));
+_PROTOTYPE(void mihand, (int j));
+_PROTOTYPE(void mqhand, (int j));
+_PROTOTYPE(void tqhand, (int j));
+_PROTOTYPE(void rehand, (int j));
+_PROTOTYPE(void mmhand, (int j));
+_PROTOTYPE(void srhand, (int j));
+_PROTOTYPE(void aahand, (int j));
+_PROTOTYPE(void iohand, (int j));
+_PROTOTYPE(void ljhand, (int j));
+_PROTOTYPE(void mahand, (int j));
+_PROTOTYPE(void mjhand, (int j));
+
+/* dismain.c */
+_PROTOTYPE(void main, (int argc, char **argv));
+
+/* distabs.c */
+_PROTOTYPE(char *getnam, (int k));
+_PROTOTYPE(int lookext, (long off, long loc, char *buf));
+_PROTOTYPE(char *lookup, (long addr, int type, int kind, long ext));
+_PROTOTYPE(char *mtrans, (int c, int m, int type));
+_PROTOTYPE(void mtrunc, (char *a));

--- a/dis88/from_elks/disfp.c
+++ b/dis88/from_elks/disfp.c
@@ -1,0 +1,141 @@
+static char *sccsid = "@(#) disfp.c, Ver. 2.1 created 00:00:00 87/09/01";
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  *  Copyright (C) 1987 G. M. Harding, all rights reserved  *
+  *                                                         *
+  * Permission to copy and  redistribute is hereby granted, *
+  * provided full source code,  with all copyright notices, *
+  * accompanies any redistribution.                         *
+  *                                                         *
+  * This file contains handler routines for the numeric op- *
+  * codes of the 8087 co-processor,  as well as a few other *
+  * opcodes which are related to 8087 emulation.            *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "dis.h"		/* Disassembler declarations  */
+
+#define FPINT0 0xd8		/* Floating-point interrupts  */
+#define FPINT1 0xd9
+#define FPINT2 0xda
+#define FPINT3 0xdb
+#define FPINT4 0xdc
+#define FPINT5 0xdd
+#define FPINT6 0xde
+#define FPINT7 0xdf
+
+			      /* Test for floating opcodes  */
+#define ISFLOP(x) (((x) >= FPINT0) && ((x) <= FPINT7))
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler for the escape  family of opcodes. *
+  * These opcodes place the contents of a specified  memory *
+  * location on the system bus,  for access by a peripheral *
+  * or by a co-processor such as the 8087. (The 8087 NDP is *
+  * accessed  only  via bus  escapes.)  Due to a bug in the *
+  * PC/IX assembler,  the "esc" mnemonic is not recognized; *
+  * consequently,  escape opcodes are disassembled as .byte *
+  * directives,  with the appropriate  mnemonic and operand *
+  * included as a comment.  FOR NOW, those escape sequences *
+  * corresponding  to 8087  opcodes  are  treated as simple *
+  * escapes.                                                *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void eshand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF eshand()  * * * * * * * * * */
+
+    register int k;
+    register char *a;
+
+    objini(j);
+
+    FETCH(k);
+
+    a = mtrans((j & 0xfd), (k & 0xc7), TR_STD);
+
+    mtrunc(a);
+
+    printf("\t.byte\t0x%02.2x\t\t| esc\t%s\n", j, a);
+
+    for (k = 1; k < objptr; ++k)
+	printf("\t.byte\t0x%02.2x\n", objbuf[k]);
+
+}				/* * * * * * * * * * * END OF eshand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler routine for floating-point opcodes. *
+  * Since PC/IX must  accommodate  systems with and without *
+  * 8087 co-processors, it allows floating-point operations *
+  * to be  initiated  in either of two ways:  by a software *
+  * interrput whose type is in the range 0xd8 through 0xdf, *
+  * or by a CPU escape sequence, which is invoked by an op- *
+  * code in the same range.  In either case, the subsequent *
+  * byte determines the actual numeric operation to be per- *
+  * formed.  However,  depending  on the  method of access, *
+  * either  one or two code bytes will  precede  that byte, *
+  * and the fphand()  routine has no way of knowing whether *
+  * it was invoked by  interrupt or by an escape  sequence. *
+  * Therefore, unlike all of the other handler routines ex- *
+  * cept dfhand(),  fphand() does not initialize the object *
+  * buffer, leaving that chore to the caller.               *
+  *                                                         *
+  * FOR NOW,  fphand()  does not disassemble floating-point *
+  * opcodes to floating  mnemonics,  but simply outputs the *
+  * object code as .byte directives.                        *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void fphand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF fphand()  * * * * * * * * * */
+    register int k;
+
+    segflg = 0;
+
+    FETCH(k);
+
+    printf("\t.byte\t0x%02.2x\t\t| 8087 code sequence\n", objbuf[0]);
+
+    for (k = 1; k < objptr; ++k)
+	printf("\t.byte\t0x%02.2x\n", objbuf[k]);
+
+#if 0
+    objout();			/* FOR NOW  */
+#endif
+
+}				/* * * * * * * * * * * END OF fphand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler for  variable  software  interrupt *
+  * opcodes.  It is included in this file because PC/IX im- *
+  * plements its software floating-point emulation by means *
+  * of interrupts.  Any interrupt in the range 0xd8 through *
+  * 0xdf is an  NDP-emulation  interrupt,  and is specially *
+  * handled by the assembler.                               *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void inhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF inhand()  * * * * * * * * * */
+
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if (ISFLOP(k)) {
+	fphand(k);
+	return;
+    }
+
+    printf("%s\t$%02x\n", optab[j].text, k);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF inhand() * * * * * * * * * * */
+

--- a/dis88/from_elks/dishand.c
+++ b/dis88/from_elks/dishand.c
@@ -1,0 +1,949 @@
+static char *sccsid = "@(#) dishand.c, Ver. 2.1 created 00:00:00 87/09/01";
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  *  Copyright (C) 1987 G. M. Harding, all rights reserved  *
+  *                                                         *
+  * Permission to copy and  redistribute is hereby granted, *
+  * provided full source code,  with all copyright notices, *
+  * accompanies any redistribution.                         *
+  *                                                         *
+  * This file contains the source code for most of the spe- *
+  * cialized handler routines of the disassembler  program. *
+  * (The file disfp.c contains handler routines specific to *
+  * the 8087 numeric  co-processor.)  Each handler  routine *
+  * interprets the opcode byte  (and subsequent data bytes, *
+  * if any)  of a particular family of opcodes,  and is re- *
+  * sponsible for generating appropriate output. All of the *
+  * code in this file is highly MACHINE-SPECIFIC, and would *
+  * have to be rewritten for a different  CPU.  The handler *
+  * routines are accessed  only via pointers in the optab[] *
+  * array, however, so machine dependencies are confined to *
+  * this file, its sister file "disfp.c", and the data file *
+  * "distabs.c".                                            *
+  *                                                         *
+  * All of the code in this file is based on the assumption *
+  * of sixteen-bit integers.                                *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "dis.h"		/* Disassembler declarations  */
+
+int segflg;			/* Segment-override flag      */
+
+unsigned char objbuf[OBJMAX];	/* Buffer for object code     */
+
+int objptr;			/* Index into objbuf[]        */
+
+unsigned long PC;		/* Current program counter    */
+
+ /* * * * * *  MISCELLANEOUS SUPPORTING ROUTINES  * * * * * */
+
+
+void objini(register int j)
+{				/* Object code init routine   */
+    if ((segflg == 1) || (segflg == 2))
+	segflg *= 3;
+    else
+	segflg = 0;
+    objptr = 0;
+    objbuf[objptr++] = (unsigned char) (j);
+}
+
+void objout(void)
+{				/* Object-code output routine */
+    register int k;
+
+    if (objflg) {
+	printf("\t|");
+	if (symptr >= 0)
+	    printf(" %05.5lx:", (PC + 1L - (long) (objptr)));
+	for (k = 0; k < objptr; ++k)
+	    printf(" %02.2x", objbuf[k]);
+	putchar('\n');
+    }
+}
+
+void badseq(register int j, register int k)
+{				/* Invalid-sequence routine   */
+    printf("\t.byte\t$%02.2x\t\t| invalid code sequence\n", j);
+    printf("\t.byte\t$%02.2x\n", k);
+}
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This  routine  is the first of several  opcode-specific *
+  * handlers,  each of which is  dedicated  to a particular *
+  * opcode family.  A pointer to a handler  routine is con- *
+  * tained in the second field of each optab[]  entry.  The *
+  * dfhand()  routine is the default handler,  invoked when *
+  * no other handler is appropriate (generally, when an in- *
+  * valid opcode is encountered).                           *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void dfhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF dfhand()  * * * * * * * * * */
+
+    segflg = 0;
+
+    printf("\t.byte\t$%02.2x", j);
+
+    if (optab[j].min || optab[j].max)
+	putchar('\n');
+    else
+	printf("\t\t| unimplemented opcode\n");
+
+}				/* * * * * * * * * * * END OF dfhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  single-byte  handler,  invoked  whenever a *
+  * one-byte opcode is encountered.                         *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void sbhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF sbhand()  * * * * * * * * * */
+
+    objini(j);
+
+    if (j == 0x2e)		/* seg cs   */
+	segflg = 1;
+
+    if ((j == 0x26)		/* seg es   */
+	||(j == 0x36)		/* seg ss   */
+	||(j == 0x3e))		/* seg ds   */
+	segflg = 2;
+
+    printf("%s\n", optab[j].text);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF sbhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for most of the processor's regular *
+  * arithmetic operations.                                  *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void aohand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF aohand()  * * * * * * * * * */
+    char b[80];
+    register int k;
+    int m, n;
+
+    objini(j);
+
+    switch (j & 7) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+	printf("%s\t", optab[j].text);
+	FETCH(k);
+	printf("%s\n", mtrans(j, k, TR_STD));
+	break;
+    case 4:
+	FETCH(k);
+	if (k < 16)
+	    printf("%s\tal,*%d\n", optab[j].text, k);
+	else
+	    printf("%s\tal,*$%02.2x\n", optab[j].text, k);
+	break;
+    case 5:
+	FETCH(m);
+	FETCH(n);
+	k = (n << 8) | m;
+	if (lookext((long) (k), (PC - 1), b))
+	    printf("%s\tax,#%s\n", optab[j].text, b);
+	else {
+	    if (k < 100 || k > 65436)
+		printf("%s\tax,#%d\n", optab[j].text, (short) k);
+	    else
+		printf("%s\tax,#$%04x\n", optab[j].text, k);
+	}
+	break;
+    default:
+	dfhand(j);
+	break;
+    }
+
+    objout();
+
+}				/* * * * * * * * * * * END OF aohand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler for opcodes  which  perform  short *
+  * (eight-bit) relative jumps.                             *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void sjhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF sjhand()  * * * * * * * * * */
+
+    register int k;
+    int m;
+    unsigned short dest;
+
+    objini(j);
+
+    FETCH(m);
+
+    if (m & 0x80)
+	k = 0xff00;
+    else
+	k = 0;
+
+    k |= m;
+    dest = (PC + k + 1);
+
+    printf("%s\t%s\t\t| loc %05.5lx\n", optab[j].text,
+	   lookup((long) dest, N_TEXT, LOOK_REL, -1L), (long) dest);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF sjhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler for a  loosely-knit  family of op- *
+  * codes which perform  arithmetic and logical operations, *
+  * and which take immediate  data.  The routine's logic is *
+  * rather complex,  so,  in an effort to avoid  additional *
+  * complexity,  the search for external  references in the *
+  * relocation table has been dispensed with. Eager hackers *
+  * can try their hand at coding such a search.             *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void imhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF imhand()  * * * * * * * * * */
+
+    static char a[128], b[32];
+    unsigned long pc;
+    register int k;
+    int offset, oflag, immed, iflag, mod, opi, w, rm;
+    int m, n;
+
+    objini(j);
+
+    FETCH(k);
+
+    pc = PC + 1;
+
+    offset = 0;
+    mod = (k & 0xc0) >> 6;
+    opi = (k & 0x38) >> 3;
+    w = j & 1;
+    rm = k & 7;
+
+    if ((j & 2)
+	&& ((opi == 1)
+	    || (opi == 4)
+	    || (opi == 6))) {
+	badseq(j, k);
+	return;
+    }
+
+    strcpy(a, OPFAM[opi]);
+
+    if (!w)
+	strcat(a, "b");
+
+    if ((oflag = mod) > 2)
+	oflag = 0;
+
+    if ((mod == 0) && (rm == 6)) {
+	FETCH(m);
+	FETCH(n);
+	offset = (n << 8) | m;
+    } else if (oflag)
+	if (oflag == 2) {
+	    FETCH(m);
+	    FETCH(n);
+	    offset = (n << 8) | m;
+	} else {
+	    FETCH(m);
+	    if (m & 0x80)
+		n = -0xFF;
+	    else
+		n = 0;
+	    offset = n | m;
+	}
+
+    switch (j & 3) {
+    case 0:
+    case 2:
+	FETCH(immed);
+	iflag = 0;
+	break;
+    case 1:
+	FETCH(m);
+	FETCH(n);
+	immed = (n << 8) | m;
+	iflag = 1;
+	break;
+    case 3:
+	FETCH(immed);
+	if (immed & 0x80)
+	    immed &= 0xff00;
+	iflag = 0;
+	break;
+    }
+
+    strcat(a, "\t");
+
+    switch (mod) {
+    case 0:
+	if (rm == 6)
+	    strcat(a, lookup((long) (offset), N_DATA, LOOK_ABS, pc));
+	else {
+	    sprintf(b, "(%s)", REGS0[rm]);
+	    strcat(a, b);
+	}
+	break;
+    case 1:
+    case 2:
+	if (mod == 1) {
+	    strcat(a, "*");
+	    sprintf(b, "%d(", (short) offset);
+	} else {
+	    strcat(a, "#");
+	    if (offset < 100 || offset > 65436)
+		sprintf(b, "%d(", (short) offset);
+	    else
+		sprintf(b, "$%04x(", offset);
+	}
+	strcat(a, b);
+	strcat(a, REGS1[rm]);
+	strcat(a, ")");
+	break;
+    case 3:
+	strcat(a, REGS[(w << 3) | rm]);
+	break;
+    }
+
+    strcat(a, ",");
+    if (iflag) {
+	strcat(a, "#");
+	if (immed < 100 || immed > 65436)
+	    sprintf(b, "%d", (short) immed);
+	else
+	    sprintf(b, "$%04x", immed);
+    } else {
+	strcat(a, "*");
+	sprintf(b, "%d", immed);
+    }
+    strcat(a, b);
+
+    printf("%s\n", a);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF imhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler  for  various  "mov"-type  opcodes *
+  * which use the mod,  reg,  and r/m  fields of the second *
+  * code byte in a standard, straightforward way.           *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mvhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mvhand()  * * * * * * * * * */
+
+    register int k, m = j;
+
+    objini(j);
+
+    FETCH(k);
+
+    if ((m == 0x84) || (m == 0x85)	/* Kind of kludgey   */
+	||(m == 0xc4) || (m == 0xc5)
+	|| (m == 0x8d))
+	if (m & 0x40)
+	    m |= 0x03;
+	else
+	    m |= 0x02;
+
+    printf("%s\t%s\n", optab[j].text, mtrans(m, k, TR_STD));
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mvhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for segment-register "mov" opcodes. *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mshand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mshand()  * * * * * * * * * */
+
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if (k & 0x20) {
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s\t%s\n", optab[j].text, mtrans(j, k, TR_SEG));
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mshand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler for pops,  other than  single-byte *
+  * pops.  (The 8088 allows  popping into any register,  or *
+  * directly into memory,  accessed  either  immediately or *
+  * through a register and an index.)                       *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void pohand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF pohand()  * * * * * * * * * */
+
+    char *a;
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if (k & 0x38) {
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s\t", optab[j].text);
+
+    a = mtrans((j & 0xfd), k, TR_STD);
+
+    mtrunc(a);
+
+    printf("%s\n", a);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF pohand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler routine for intersegment  calls and *
+  * jumps.  Its output is never symbolic,  because the host *
+  * linker  does not allow  symbolic  intersegment  address *
+  * references except by means of symbolic  constants,  and *
+  * any such  constants in the symbol  table,  even if they *
+  * are of the  appropriate  value,  may be misleading.  In *
+  * compiled code,  intersegment  references  should not be *
+  * encountered,  and even in assembled  code,  they should *
+  * occur infrequently. If and when they do occur, however, *
+  * they will be disassembled in absolute form.             *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void cihand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF cihand()  * * * * * * * * * */
+
+    register int m, n;
+
+    objini(j);
+
+    printf("%s\t", optab[j].text);
+
+    FETCH(m);
+    FETCH(n);
+
+    printf("#$%04.4x,", ((n << 8) | m));
+
+    FETCH(m);
+    FETCH(n);
+
+    printf("#$%04.4x\n", ((n << 8) | m));
+
+    objout();
+
+}				/* * * * * * * * * * * END OF cihand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for  "mov"  opcodes with  immediate *
+  * data.                                                   *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mihand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mihand()  * * * * * * * * * */
+
+    register int k;
+    int m, n;
+    char b[80];
+
+    objini(j);
+
+    printf("%s", optab[j].text);
+
+    if (j & 8) {
+	FETCH(m);
+	FETCH(n);
+	k = ((n << 8) | m);
+	if (lookext((long) (k), (PC - 1), b))
+	    printf("#%s\n", b);
+	else {
+	    if (k < 100 || k > 65436)
+		printf("#%d\n", (short) k);
+	    else
+		printf("#$%04x\n", k);
+	}
+    } else {
+	FETCH(m);
+	printf("*%d\n", m);
+    }
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mihand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for a family of quick-move opcodes. *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mqhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mqhand()  * * * * * * * * * */
+
+    unsigned long pc;
+    register int m, n;
+
+    objini(j);
+
+    pc = PC + 1;
+
+    FETCH(m);
+    FETCH(n);
+
+    m = (n << 8) | m;
+
+    printf("%s\t", optab[j].text);
+
+    if (j & 2)
+	printf("%s,%s\n",
+	       lookup((long) (m), N_DATA, LOOK_ABS, pc), REGS[(j & 1) << 3]);
+    else
+	printf("%s,%s\n",
+	       REGS[(j & 1) << 3], lookup((long) (m), N_DATA, LOOK_ABS, pc));
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mqhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for a family of quick-test opcodes. *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void tqhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF tqhand()  * * * * * * * * * */
+
+    char b[80];
+    register int m, n;
+    int k;
+
+    objini(j);
+
+    printf("%s\t%s,", optab[j].text, REGS[(j & 1) << 3]);
+
+    FETCH(m);
+
+    if (j & 1) {
+	FETCH(n);
+	k = ((n << 8) | m);
+	if (lookext((long) (k), (PC - 1), b))
+	    printf("#%s\n", b);
+	else {
+	    if (k < 100 || k > 65436)
+		printf("#%d\n", (short) k);
+	    else
+		printf("#$%04x\n", k);
+	}
+    } else {
+	if (m & 80)
+	    m |= -0xFF;
+	printf("*%d\n", m);
+    }
+
+    objout();
+
+}				/* * * * * * * * * * * END OF tqhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for multiple-byte "return" opcodes. *
+  * The 8088 allows returns to take an optional  16-bit ar- *
+  * gument,  which  reflects  the  amount to be added to SP *
+  * after  the pop of the  return  address.  The idea is to *
+  * facilitate  the use of local  parameters  on the stack. *
+  * After some  rumination,  it was decided to  disassemble *
+  * any such arguments as absolute quantities,  rather than *
+  * rummaging  through the symbol table for possible corre- *
+  * sponding constants.                                     *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void rehand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF rehand()  * * * * * * * * * */
+
+    register int m, n;
+
+    objini(j);
+
+    FETCH(m);
+    FETCH(n);
+
+    m = (n << 8) | m;
+
+    printf("%s\t#0x%04.4x\n", optab[j].text, m);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF rehand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for "mov"  opcodes involving memory *
+  * and immediate data.                                     *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mmhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mmhand()  * * * * * * * * * */
+
+    char b[80];
+    char *a;
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if (k & 0x38) {
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s", optab[j].text);
+
+    if (!(j & 1))
+	putchar('b');
+
+    a = mtrans((j & 0xfd), (k & 0xc7), TR_STD);
+
+    mtrunc(a);
+
+    printf("\t%s,", a);
+
+    if (j & 1) {
+	FETCH(j);
+	FETCH(k);
+	k = (k << 8) | j;
+	if (lookext((long) (k), (PC - 1), b))
+	    printf("#%s\n", b);
+	else {
+	    if (k < 100 || k > 65436)
+		printf("#%d\n", (short) k);
+	    else
+		printf("#$%04x\n", k);
+	}
+    } else {
+	FETCH(k);
+	printf("*%d\n", k);
+    }
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mmhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler  for the 8088  family of shift and *
+  * rotate instructions.                                    *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void srhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF srhand()  * * * * * * * * * */
+
+    char *a;
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if ((k & 0x38) == 0x30) {
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s", OPFAM[((k & 0x38) >> 3) + 16]);
+
+    if (!(j & 1))
+	putchar('b');
+
+    a = mtrans((j & 0xfd), (k & 0xc7), TR_STD);
+
+    mtrunc(a);
+
+    printf("\t%s", a);
+
+    if (j & 2)
+	printf(",cl\n");
+    else
+	printf(",*1\n");
+
+    objout();
+
+}				/* * * * * * * * * * * END OF srhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for the ASCII-adjust opcodes.       *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void aahand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF aahand()  * * * * * * * * * */
+
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    if (k != 0x0a) {
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s\n", optab[j].text);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF aahand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for port I/O opcodes  which specify *
+  * the port address as an immediate operand.               *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void iohand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF iohand()  * * * * * * * * * */
+
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    printf("%s\t$%02.2x\n", optab[j].text, k);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF iohand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the  handler  for opcodes  which  perform  long *
+  * (sixteen-bit) relative jumps and calls.                 *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void ljhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF ljhand()  * * * * * * * * * */
+
+    register int k;
+    int m, n;
+    unsigned short dest;
+
+    objini(j);
+
+    FETCH(m);
+    FETCH(n);
+
+    k = (n << 8) | m;
+    dest = PC + k + 1;
+
+    printf("%s\t%s\t\t| loc %05.5lx\n", optab[j].text,
+	   lookup((long) dest, N_TEXT, LOOK_LNG, (PC - 1L)), (long) dest);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF ljhand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for a pair of oddball opcodes (0xf6 *
+  * and 0xf7) which perform miscellaneous arithmetic opera- *
+  * tions not dealt with elsewhere.                         *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mahand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mahand()  * * * * * * * * * */
+
+    char *a;
+    register int k;
+    char b[80];
+
+    objini(j);
+
+    FETCH(k);
+
+    a = mtrans((j & 0xfd), (k & 0xc7), TR_STD);
+
+    mtrunc(a);
+
+    switch (((k = objbuf[1]) & 0x38) >> 3) {
+    case 0:
+	printf("\ttest");
+	break;
+    case 1:
+	badseq(j, k);
+	return;
+    case 2:
+	printf("\tnot");
+	break;
+    case 3:
+	printf("\tneg");
+	break;
+    case 4:
+	printf("\tmul");
+	break;
+    case 5:
+	printf("\timul");
+	break;
+    case 6:
+	printf("\tdiv");
+	break;
+    case 7:
+	printf("\tidiv");
+	break;
+    }
+
+    if (!(j & 1))
+	putchar('b');
+
+    printf("\t%s", a);
+
+    if (k & 0x38)
+	putchar('\n');
+    else if (j & 1) {
+	FETCH(j);
+	FETCH(k);
+	k = (k << 8) | j;
+	if (lookext((long) (k), (PC - 1), b))
+	    printf(",#%s\n", b);
+	else
+	    printf(",#$%04x\n", k);
+    } else {
+	FETCH(k);
+	printf(",*%d\n", k);
+    }
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mahand() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the handler for miscellaneous jump, call, push, *
+  * and increment/decrement opcodes  (0xfe and 0xff)  which *
+  * are not dealt with elsewhere.                           *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mjhand(register int j)
+{				/* Pointer to optab[] entry   *//* * * * * * * * * *  START OF mjhand()  * * * * * * * * * */
+
+    char *a;
+    register int k;
+
+    objini(j);
+
+    FETCH(k);
+
+    a = mtrans((j & 0xfd), (k & 0xc7), TR_STD);
+
+    mtrunc(a);
+
+    switch (((k = objbuf[1]) & 0x38) >> 3) {
+    case 0:
+	printf("\tinc");
+	if (!(j & 1))
+	    putchar('b');
+	putchar('\t');
+	break;
+    case 1:
+	printf("\tdec");
+	if (!(j & 1))
+	    putchar('b');
+	putchar('\t');
+	break;
+    case 2:
+	if (j & 1)
+	    printf("\tcall\t@");
+	else
+	    goto BAD;
+	break;
+    case 3:
+	if (j & 1)
+	    printf("\tcalli\t@");
+	else
+	    goto BAD;
+	break;
+    case 4:
+	if (j & 1)
+	    printf("\tjmp\t@");
+	else
+	    goto BAD;
+	break;
+    case 5:
+	if (j & 1)
+	    printf("\tjmpi\t@");
+	else
+	    goto BAD;
+	break;
+    case 6:
+	if (j & 1)
+	    printf("\tpush\t");
+	else
+	    goto BAD;
+	break;
+    case 7:
+      BAD:
+	badseq(j, k);
+	return;
+    }
+
+    printf("%s\n", a);
+
+    objout();
+
+}				/* * * * * * * * * * * END OF mjhand() * * * * * * * * * * */
+

--- a/dis88/from_elks/disimg.1
+++ b/dis88/from_elks/disimg.1
@@ -1,0 +1,31 @@
+.TH disimg 1 LOCAL
+.SH "NAME"
+disimg \- 8088 symbolic disassembler
+.SH "SYNOPSIS"
+\fBdisimg\fP [ -f -o ] ifile [ ofile ]
+.SH "DESCRIPTION"
+Disimg reads ifile, which must be in EPOC .img format.
+It interprets the binary opcodes and data locations, and
+writes corresponding assembler source code to stdout, or
+to ofile if specified.  The program's output is in the
+format of, and fully compatible with, the as86 assembler,
+as86(1). The disassembler will make all necessary 
+adjustments in address-reference calculations.
+.PP
+If the "-o" option appears, object code will be included
+in comments during disassembly of the text segment.  This
+feature is used primarily for debugging the disassembler
+itself, but may provide information of passing interest
+to users.
+.PP
+If the "-f" option appears, disimg will attempt to disassemble
+any file whatsoever. It has to assume that the file begins
+at address zero.
+.PP
+Since this program is essentially dis88 for .img files,
+you should read the
+.B dis88
+man page, bearing in mind that .img files have no symbol
+table, and are "split I&D" files.
+.SH "SEE ALSO"
+dis88(1).

--- a/dis88/from_elks/dismain.c
+++ b/dis88/from_elks/dismain.c
@@ -1,0 +1,612 @@
+static char *sccsid = "@(#) dismain.c, Ver. 2.1 created 00:00:00 87/09/01";
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  *  Copyright (C) 1987 G. M. Harding, all rights reserved  *
+  *                                                         *
+  * Permission to copy and  redistribute is hereby granted, *
+  * provided full source code,  with all copyright notices, *
+  * accompanies any redistribution.                         *
+  *                                                         *
+  * This file  contains  the source  code for the  machine- *
+  * independent  portions of a disassembler  program to run *
+  * in a Unix (System III) environment.  It expects, as its *
+  * input, a file in standard a.out format, optionally con- *
+  * taining symbol table information.  If a symbol table is *
+  * present, it will be used in the disassembly; otherwise, *
+  * all address references will be literal (absolute).      *
+  *                                                         *
+  * The disassembler  program was originally written for an *
+  * Intel 8088 CPU.  However, all details of the actual CPU *
+  * architecture are hidden in three machine-specific files *
+  * named  distabs.c,  dishand.c,  and disfp.c  (the latter *
+  * file is specific to the 8087 numeric co-processor). The *
+  * code in this file is generic,  and should require mini- *
+  * mal revision if a different CPU is to be targeted. If a *
+  * different version of Unix is to be targeted, changes to *
+  * this file may be necessary, and if a completely differ- *
+  * ent OS is to be targeted, all bets are off.             *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "dis.h"		/* Disassembler declarations  */
+
+extern char *release;		/* Contains release string    */
+static char *IFILE = NULL;	/* Points to input file name  */
+static char *OFILE = NULL;	/* Points to output file name */
+static char *PRG;		/* Name of invoking program   */
+static unsigned long zcount;	/* Consecutive "0" byte count */
+int objflg = 0;			/* Flag: output object bytes  */
+int force = 0;			/* Flag: override some checks */
+
+#define unix 1
+#define i8086 1
+#define ibmpc 1
+
+#if unix && i8086 && ibmpc	/* Set the CPU identifier     */
+static int cpuid = 1;
+#else
+static int cpuid = 0;
+#endif
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+_PROTOTYPE(static void prolog, (void));
+_PROTOTYPE(static void distext, (void));
+_PROTOTYPE(static void disdata, (void));
+_PROTOTYPE(static void disbss, (void));
+
+ /* * * * * * * MISCELLANEOUS UTILITY FUNCTIONS * * * * * * */
+
+static void usage(register char *s)
+{
+    fprintf(stderr, "Usage: %s [-o] ifile [ofile]\n", s);
+    exit(-1);
+}
+
+static void fatal(register char *s, register char *t)
+{
+    fprintf(stderr, "%s: %s\n", s, t);
+    exit(-1);
+}
+
+static void zdump(unsigned long beg)
+{
+    beg = PC - beg;
+    if (beg > 1L)
+	printf("\t.zerow\t%ld\n", (beg >> 1));
+    if (beg & 1L)
+	printf("\t.byte\t0\n");
+}
+
+static char *invoker(register char *s)
+{
+    register int k;
+
+    k = strlen(s);
+
+    while (k--)
+	if (s[k] == '/') {
+	    s += k;
+	    ++s;
+	    break;
+	}
+
+    return s;
+}
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This rather tricky routine supports the disdata() func- *
+  * tion.  Its job is to output the code for a sequence  of *
+  * data bytes whenever the object buffer is full,  or when *
+  * a symbolic label is to be output. However, it must also *
+  * keep track of  consecutive  zero words so that  lengthy *
+  * stretches of null data can be  compressed by the use of *
+  * an  appropriate  assembler  pseudo-op.  It does this by *
+  * setting and testing a file-wide  flag which counts suc- *
+  * cessive full buffers of null data. The function returns *
+  * a logical  TRUE value if it outputs  anything,  logical *
+  * FALSE otherwise.  (This enables disdata()  to determine *
+  * whether to output a new  synthetic  label when there is *
+  * no symbol table.)                                       *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static int objdump(register char *c)
+{				/* * * * * * * * * * START OF  objdump() * * * * * * * * * */
+
+    register int k, j;
+    int retval = 0;
+
+    if (objptr == OBJMAX) {
+	for (k = 0; k < OBJMAX; ++k)
+	    if (objbuf[k])
+		break;
+	if (k == OBJMAX) {
+	    zcount += k;
+	    objptr = 0;
+	    if (c == NULL)
+		return retval;
+	}
+    }
+
+    if (zcount) {
+	printf("\t.zerow\t%ld\n", (zcount >> 1));
+	++retval;
+	zcount = 0L;
+    }
+
+    if (objptr) {
+	printf("\t.byte\t");
+	++retval;
+    } else
+	return retval;
+
+    for (k = 0; k < objptr; ++k) {
+	printf("$%02.2x", objbuf[k]);
+	if (k < (objptr - 1))
+	    putchar(',');
+    }
+
+    for (k = objptr; k < OBJMAX; ++k)
+	printf("    ");
+
+    printf("    | \"");
+
+    for (k = 0; k < objptr; ++k) {
+	if (objbuf[k] > ' ' && objbuf[k] <= '~')
+	    putchar(objbuf[k]);
+	else
+	    switch (objbuf[k]) {
+	    case '\t':
+		printf("\\t");
+		break;
+	    case '\n':
+		printf("\\n");
+		break;
+	    case '\f':
+		printf("\\f");
+		break;
+	    case '\r':
+		printf("\\r");
+		break;
+	    default:
+		putchar('.');
+		break;
+	    }
+    }
+    printf("\"\n");
+
+    objptr = 0;
+
+    return retval;
+
+}				/* * * * * * * * * *  END OF  objdump()  * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This  routine,  called  at the  beginning  of the input *
+  * cycle for each object byte,  and before any interpreta- *
+  * tion is  attempted,  searches  the symbol table for any *
+  * symbolic  name with a value  corresponding  to the cur- *
+  * rent PC and a type  corresponding  to the segment  type *
+  * (i.e.,  text, data, or bss) specified by the function's *
+  * argument. If any such name is found, a pointer to it is *
+  * returned; otherwise, a NULL pointer is returned.        *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static char *getlab(register int type)
+{				/* * * * * * * * * *  START OF getlab()  * * * * * * * * * */
+
+    register int k;
+    static char b[48], c[32];
+
+    if (symptr < 0)
+	if ((type == N_TEXT)
+	    || ((type == N_DATA) && (!objptr) && (!zcount))) {
+	    if (type == N_TEXT)
+		sprintf(b, "T%05.5lx:", PC);
+	    else
+		sprintf(b, "D%05.5lx:", PC);
+	    return b;
+	} else
+	    return NULL;
+
+    for (k = 0; k <= symptr; ++k)
+	if ((symtab[k].n_value == PC)
+	    && ((symtab[k].n_sclass & N_SECT) == type)) {
+	    sprintf(b, "%s:\n", getnam(k));
+	    if (objflg && (type != N_TEXT))
+		sprintf(c, "| %05.5lx\n", PC);
+	    strcat(b, c);
+	    return b;
+	}
+
+    return NULL;
+
+}				/* * * * * * * * * * * END OF getlab() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This routine  performs a preliminary scan of the symbol *
+  * table,  before disassembly begins, and outputs declara- *
+  * tions of globals and constants.                         *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static void prolog(void)
+{				/* * * * * * * * * *  START OF prolog()  * * * * * * * * * */
+
+    register int j, flag;
+
+    fflush(stdout);
+
+    if (symptr < 0)
+	return;
+
+    for (j = flag = 0; j <= symptr; ++j)
+	if ((symtab[j].n_sclass & N_CLASS) == C_EXT)
+	    if (((symtab[j].n_sclass & N_SECT) > N_UNDF)
+		&& ((symtab[j].n_sclass & N_SECT) < N_COMM)) {
+		char *c = getnam(j);
+		printf("\t.globl\t%s", c);
+		if (++flag == 1) {
+		    putchar('\t');
+		    if (strlen(c) < 8)
+			putchar('\t');
+		    printf("| Internal global\n");
+		} else
+		    putchar('\n');
+	    } else if (symtab[j].n_value) {
+		char *c = getnam(j);
+		printf("\t.comm\t%s,0x%08.8lx", c, symtab[j].n_value);
+		if (++flag == 1)
+		    printf("\t| Internal global\n");
+		else
+		    putchar('\n');
+	    }
+
+    if (flag)
+	putchar('\n');
+    fflush(stdout);
+
+    for (j = flag = 0; j <= relptr; ++j)
+	if (relo[j].r_symndx < S_BSS) {
+	    char *c = getnam(relo[j].r_symndx);
+	    ++flag;
+	    printf("\t.globl\t%s", c);
+	    putchar('\t');
+	    if (strlen(c) < 8)
+		putchar('\t');
+	    printf("| Undef: %05.5lx\n", relo[j].r_vaddr);
+	}
+
+    if (flag)
+	putchar('\n');
+    fflush(stdout);
+
+    for (j = flag = 0; j <= symptr; ++j)
+	if ((symtab[j].n_sclass & N_SECT) == N_ABS) {
+	    char *c = getnam(j);
+	    printf("%s=0x%08.8lx", c, symtab[j].n_value);
+	    if (++flag == 1) {
+		printf("\t\t");
+		if (strlen(c) < 5)
+		    putchar('\t');
+		printf("| Literal\n");
+	    } else
+		putchar('\n');
+	}
+
+    if (flag)
+	putchar('\n');
+    fflush(stdout);
+
+}				/* * * * * * * * * * * END OF prolog() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This function is  responsible  for  disassembly  of the *
+  * object file's text segment.                             *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static void distext(void)
+{				/* * * * * * * * * * START OF  distext() * * * * * * * * * */
+
+    char *c;
+    register int j;
+    register void (*f) ();
+
+    for (j = 0; j < (int) (HDR.HeaderSizeBytes); ++j)
+	getchar();
+
+    printf("| %s, %s\n\n", PRG, release);
+
+    printf("| @(");
+
+    printf("#)\tDisassembly of %s", IFILE);
+
+    if (symptr < 0)
+	printf(" (no symbols)\n\n");
+    else
+	printf("\n\n");
+
+    prolog();			/* Should do nowt, since symptr == 0 */
+
+    printf("\t.text\t\t\t| loc = %05.5lx, size = %05.5lx\n\n",
+	   PC, HDR.CodeParas * 16);
+    fflush(stdout);
+
+    segflg = 0;
+
+    for (PC = 0L; PC < HDR.CodeParas * 16; ++PC) {
+	j = getchar();
+	if (j == EOF)
+	    break;
+	j &= 0xFF;
+	if ((j == 0) && ((PC + 1L) == HDR.CodeParas * 16)) {
+	    ++PC;
+	    break;
+	}
+	if ((c = getlab(N_TEXT)) != NULL)
+	    printf("%s", c);
+	if (j >= 0 && j < 256) {
+	    f = optab[j].func;
+	    (*f) (j);
+	}
+	fflush(stdout);
+    }
+
+}				/* * * * * * * * * *  END OF  distext()  * * * * * * * * * */
+
+#if 0
+#define FETCH(p)  ++PC; p = getchar() & 0xff; objbuf[objptr++] = p
+#endif
+
+int Fetch(void)
+{
+    int p;
+
+    ++PC;
+    if (symptr >= 0 && getlab(N_TEXT) != NULL) {
+	--PC;
+	return -1;
+    }
+    p = getchar();
+    objbuf[objptr++] = p;
+    return p;
+}
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This  function  handles the object file's data segment. *
+  * There is no good way to disassemble a data segment, be- *
+  * cause it is  impossible  to tell,  from the object code *
+  * alone,  what each data byte refers to.  If it refers to *
+  * an external symbol,  the reference can be resolved from *
+  * the relocation table, if there is one.  However,  if it *
+  * refers to a static symbol,  it cannot be  distinguished *
+  * from numeric, character, or other pointer data. In some *
+  * cases,  one might make a semi-educated  guess as to the *
+  * nature of the data,  but such  guesses  are  inherently *
+  * haphazard,  and they are  bound to be wrong a good por- *
+  * tion of the time.  Consequently,  the data  segment  is *
+  * disassembled  as a byte  stream,  which will satisfy no *
+  * one but which, at least, will never mislead anyone.     *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static void disdata(void)
+{				/* * * * * * * * * * START OF  disdata() * * * * * * * * * */
+
+    unsigned long end;
+    register char *c;
+    register int j;
+
+    putchar('\n');
+    if (HDR.InitialisedData == 0)
+	return;
+
+    PC = /*0L */ HDR.StackParas * 16;
+    end = PC + HDR.InitialisedData;
+
+    printf("\t.data\t\t\t| loc = %05.5lx, size = %05.5lx\n\n",
+	   PC, HDR.InitialisedData);
+
+    segflg = 0;
+
+    for (objptr = 0, zcount = 0L; PC < end; ++PC) {
+	if ((c = getlab(N_DATA)) != NULL) {
+	    objdump(c);
+	    printf("%s", c);
+	}
+	if (objptr >= OBJMAX)
+	    if (objdump(NULL) && (symptr < 0))
+		printf("D%05.5lx:", PC);
+	j = getchar() & 0xff;
+	objbuf[objptr++] = j;
+    }
+
+    objdump("");
+
+}				/* * * * * * * * * *  END OF  disdata()  * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This  function  handles the object  file's bss segment. *
+  * Disassembly of the bss segment is easy,  because every- *
+  * thing in it is zero by definition.                      *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+static void disbss(void)
+{				/* * * * * * * * * *  START OF disbss()  * * * * * * * * * */
+
+    unsigned long beg, end;
+    register char *c;
+    register int j;
+
+    putchar('\n');
+
+    if (HDR.InitialisedData == HDR.DataParas * 16)
+	return;
+
+    end = HDR.DataParas * 16 - HDR.InitialisedData;
+
+    printf("\t.bss\t\t\t| loc = %05.5lx, size = %05.5lx\n\n", PC, end);
+
+    segflg = 0;
+
+    for (beg = PC; PC < end; ++PC)
+	if ((c = getlab(N_BSS)) != NULL) {
+	    if (PC > beg) {
+		zdump(beg);
+		beg = PC;
+	    }
+	    printf("%s", c);
+	}
+
+    if (PC > beg)
+	zdump(beg);
+
+}				/* * * * * * * * * * * END OF disbss() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This is the program  entry  point.  The command line is *
+  * searched for an input file name, which must be present. *
+  * An optional output file name is also permitted; if none *
+  * is found, standard output is the default.  One command- *
+  * line option is available:  "-o",  which causes the pro- *
+  * gram to include  object code in comments along with its *
+  * mnemonic output.                                        *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int main(int argc, register char **argv)
+{				/* * * * * * * * * * * START OF main() * * * * * * * * * * */
+
+    char a[1024];
+    register int fd;
+    long taboff, tabnum;
+    long reloff, relnum;
+
+    PRG = invoker(*argv);
+
+    while (*++argv != NULL)	/* Process command-line args  */
+	if (**argv == '-')
+	    switch (*++*argv) {
+	    case 'o':
+		if (*++*argv)
+		    usage(PRG);
+		else
+		    ++objflg;
+		break;
+	    case 'f':
+		force++;
+		break;
+	    default:
+		usage(PRG);
+	} else if (IFILE == NULL)
+	    IFILE = *argv;
+	else if (OFILE == NULL)
+	    OFILE = *argv;
+	else
+	    usage(PRG);
+
+    if (IFILE == NULL)
+	usage(PRG);
+    else if ((fd = open(IFILE, O_RDONLY | O_BINARY)) < 0) {
+	sprintf(a, "can't access input file %s", IFILE);
+	fatal(PRG, a);
+    }
+
+    if (OFILE != NULL)
+	if (freopen(OFILE, "w", stdout) == NULL) {
+	    sprintf(a, "can't open output file %s", OFILE);
+	    fatal(PRG, a);
+	}
+
+    if (!cpuid)
+	fprintf(stderr, "%s: warning: host/cpu clash\n", PRG);
+
+    read(fd, (char *) &HDR, sizeof(ImgHeader));
+
+    if (strncmp("ImageFileType**", HDR.Signature, 16) != 0) {
+	sprintf(a, "input file %s not in .img format", IFILE);
+	fatal(PRG, a);
+    }
+
+    /*{
+     * HDR.a_trsize = HDR.a_drsize = 0L;
+     * HDR.a_tbase = HDR.a_dbase = 0L;
+     * } */
+
+    /*reloff = HDR.a_text        * Compute reloc data offset  *
+     * + HDR.a_data
+     * + (long)(HDR.a_hdrlen); */
+    reloff = 0;
+
+    relnum = 0;
+    /*(HDR.a_trsize + HDR.a_drsize) / sizeof(struct reloc); */
+
+    /*taboff = reloff            * Compute name table offset  *
+     * + HDR.a_trsize
+     * + HDR.a_drsize; */
+    taboff = 0;
+
+    /*tabnum = HDR.a_syms / sizeof(struct nlist); */
+    tabnum = 0;
+
+    if (relnum > MAXSYM)
+	fatal(PRG, "reloc table overflow");
+
+    if (tabnum > MAXSYM)
+	fatal(PRG, "symbol table overflow");
+
+    /*if (relnum)                            * Get reloc data *
+     * if (lseek(fd,reloff,0) != reloff)
+     * fatal(PRG,"lseek error");
+     * else
+     * {
+     * for (relptr = 0; relptr < relnum; ++relptr)
+     * read(fd, (char *) &relo[relptr],sizeof(struct reloc));
+     * relptr--;
+     * }
+     * 
+     * if (tabnum)                            * Read in symtab *
+     * if (lseek(fd,taboff,0) != taboff)
+     * fatal(PRG,"lseek error");
+     * else
+     * {
+     * for (symptr = 0; symptr < tabnum; ++symptr)
+     * read(fd, (char *) &symtab[symptr],sizeof(struct nlist));
+     * symptr--;
+     * } */
+
+    close(fd);
+
+#ifdef MSDOS
+    if (freopen(IFILE, "rb", stdin) == NULL)
+#else
+    if (freopen(IFILE, "r", stdin) == NULL)
+#endif
+    {
+	sprintf(a, "can't reopen input file %s", IFILE);
+	fatal(PRG, a);
+    }
+
+    distext();
+
+    disdata();
+
+    disbss();
+
+    exit(0);
+
+}				/* * * * * * * * * * *  END OF main()  * * * * * * * * * * */

--- a/dis88/from_elks/disrel.c
+++ b/dis88/from_elks/disrel.c
@@ -1,0 +1,29 @@
+static char *copyright =
+    "@(#) Copyright (C) 1987 G. M. Harding, all rights reserved";
+
+#ifdef __linux__
+char *release = "released with Psion-bcc toolset for Linux";
+#else
+static char *sccsid = "@(#) disrel.c, Ver. 2.1 created 00:00:00 87/09/01";
+char *release = "release 2.1 (MINIX)";
+#endif
+
+ /*
+  * **
+  * ** This file documents the major revisions to the 8088 symbolic
+  * ** disassembler. It also contains the release string which is
+  * ** output at the head of each disassembly, and the copyright
+  * ** string which must be incorporated in any code distribution.
+  * **
+  * ** Permission to copy and redistribute is hereby granted,
+  * ** provided full source code, with all copyright notices,
+  * ** accompanies any redistribution.
+  * **
+  * ** REVISION HISTORY:
+  * **
+  * ** SEP 87:
+  * **    After internal shakeout, released on Usenet.
+  * **
+  * ** JUN 88:
+  * **    Ported to MINIX
+  */

--- a/dis88/from_elks/distabs.c
+++ b/dis88/from_elks/distabs.c
@@ -1,0 +1,668 @@
+static char *sccsid = "@(#) distabs.c, Ver. 2.1 created 00:00:00 87/09/01";
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  *  Copyright (C) 1987 G. M. Harding, all rights reserved  *
+  *                                                         *
+  * Permission to copy and  redistribute is hereby granted, *
+  * provided full source code,  with all copyright notices, *
+  * accompanies any redistribution.                         *
+  *                                                         *
+  * This file  contains  the  lookup  tables and other data *
+  * structures for the Intel 8088 symbolic disassembler. It *
+  * also contains a few global  routines  which  facilitate *
+  * access to the tables,  for use primarily by the handler *
+  * functions.                                              *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "dis.h"		/* Disassembler declarations  */
+
+ImgHeader HDR;			/* Used to hold header info   */
+
+struct nlist symtab[MAXSYM];	/* Array of symbol table info */
+
+struct reloc relo[MAXSYM];	/* Array of relocation info   */
+
+int symptr = -1,		/* Index into symtab[]        */
+  relptr = -1;			/* Index into relo[]          */
+
+char *REGS[] =			/* Table of register names    */
+{
+    "al", "cl", "dl", "bl", "ah", "ch", "dh", "bh",
+    "ax", "cx", "dx", "bx", "sp", "bp", "si", "di",
+    "es", "cs", "ss", "ds"
+};
+
+char *REGS0[] =			/* Mode 0 register name table */
+{
+    "bx_si", "bx_di", "bp_si", "bp_di", "si", "di", "", "bx"
+};
+
+char *REGS1[] =			/* Mode 1 register name table */
+{
+    "bx_si", "bx_di", "bp_si", "bp_di", "si", "di", "bp", "bx"
+};
+
+int symrank[6][6] =		/* Symbol type/rank matrix    */
+{
+    /* UND  ABS  TXT  DAT  BSS  COM */
+    /* UND */ 5, 4, 1, 2, 3, 0,
+    /* ABS */ 1, 5, 4, 3, 2, 0,
+    /* TXT */ 4, 1, 5, 3, 2, 0,
+    /* DAT */ 3, 1, 2, 5, 4, 0,
+    /* BSS */ 3, 1, 2, 4, 5, 0,
+    /* COM */ 2, 0, 1, 3, 4, 5
+};
+
+ /* * * * * * * * * * * * OPCODE DATA * * * * * * * * * * * */
+
+char ADD[] = "\tadd",		/* Mnemonics by family  */
+  OR[] = "\tor",
+    ADC[] = "\tadc",
+    SBB[] = "\tsbb",
+    AND[] = "\tand",
+    SUB[] = "\tsub",
+    XOR[] = "\txor",
+    CMP[] = "\tcmp",
+    NOT[] = "\tnot",
+    NEG[] = "\tneg",
+    MUL[] = "\tmul",
+    DIV[] = "\tdiv",
+    MOV[] = "\tmov",
+    ESC[] = "\tesc",
+    TEST[] = "\ttest",
+    AMBIG[] = "",
+    ROL[] = "\trol",
+    ROR[] = "\tror",
+    RCL[] = "\trcl",
+    RCR[] = "\trcr",
+    SAL[] = "\tsal", SHR[] = "\tshr", SHL[] = "\tshl", SAR[] = "\tsar";
+
+char *OPFAM[] =			/* Family lookup table  */
+{
+    ADD, OR, ADC, SBB, AND, SUB, XOR, CMP,
+    NOT, NEG, MUL, DIV, MOV, ESC, TEST, AMBIG,
+    ROL, ROR, RCL, RCR, SAL, SHR, SHL, SAR
+};
+
+struct opcode optab[] =		/* Table of opcode data */
+{
+    ADD, aohand, 2, 4,		/* 0x00  */
+    ADD, aohand, 2, 4,		/* 0x01  */
+    ADD, aohand, 2, 4,		/* 0x02  */
+    ADD, aohand, 2, 4,		/* 0x03  */
+    ADD, aohand, 2, 2,		/* 0x04  */
+    ADD, aohand, 3, 3,		/* 0x05  */
+    "\tpush\tes", sbhand, 1, 1,	/* 0x06  */
+    "\tpop\tes", sbhand, 1, 1,	/* 0x07  */
+    OR, aohand, 2, 4,		/* 0x08  */
+    OR, aohand, 2, 4,		/* 0x09  */
+    OR, aohand, 2, 4,		/* 0x0a  */
+    OR, aohand, 2, 4,		/* 0x0b  */
+    OR, aohand, 2, 2,		/* 0x0c  */
+    OR, aohand, 3, 3,		/* 0x0d  */
+    "\tpush\tcs", sbhand, 1, 1,	/* 0x0e  */
+    "\t.code\t386", sbhand, 1, 1,	/* 0x0f  */
+    ADC, aohand, 2, 4,		/* 0x10  */
+    ADC, aohand, 2, 4,		/* 0x11  */
+    ADC, aohand, 2, 4,		/* 0x12  */
+    ADC, aohand, 2, 4,		/* 0x13  */
+    ADC, aohand, 2, 2,		/* 0x14  */
+    ADC, aohand, 3, 3,		/* 0x15  */
+    "\tpush\tss", sbhand, 1, 1,	/* 0x16  */
+    "\tpop\tss", sbhand, 1, 1,	/* 0x17  */
+    SBB, aohand, 2, 4,		/* 0x18  */
+    SBB, aohand, 2, 4,		/* 0x19  */
+    SBB, aohand, 2, 4,		/* 0x1a  */
+    SBB, aohand, 2, 4,		/* 0x1b  */
+    SBB, aohand, 2, 2,		/* 0x1c  */
+    SBB, aohand, 3, 3,		/* 0x1d  */
+    "\tpush\tds", sbhand, 1, 1,	/* 0x1e  */
+    "\tpop\tds", sbhand, 1, 1,	/* 0x1f  */
+    AND, aohand, 2, 4,		/* 0x20  */
+    AND, aohand, 2, 4,		/* 0x21  */
+    AND, aohand, 2, 4,		/* 0x22  */
+    AND, aohand, 2, 4,		/* 0x23  */
+    AND, aohand, 2, 2,		/* 0x24  */
+    AND, aohand, 3, 3,		/* 0x25  */
+    "\tseg\tes", sbhand, 1, 1,	/* 0x26  */
+    "\tdaa", sbhand, 1, 1,	/* 0x27  */
+    SUB, aohand, 2, 4,		/* 0x28  */
+    SUB, aohand, 2, 4,		/* 0x29  */
+    SUB, aohand, 2, 4,		/* 0x2a  */
+    SUB, aohand, 2, 4,		/* 0x2b  */
+    SUB, aohand, 2, 2,		/* 0x2c  */
+    SUB, aohand, 3, 3,		/* 0x2d  */
+    "\tseg\tcs", sbhand, 1, 1,	/* 0x2e  */
+    "\tdas", sbhand, 1, 1,	/* 0x2f  */
+    XOR, aohand, 2, 4,		/* 0x30  */
+    XOR, aohand, 2, 4,		/* 0x31  */
+    XOR, aohand, 2, 4,		/* 0x32  */
+    XOR, aohand, 2, 4,		/* 0x33  */
+    XOR, aohand, 2, 2,		/* 0x34  */
+    XOR, aohand, 3, 3,		/* 0x35  */
+    "\tseg\tss", sbhand, 1, 1,	/* 0x36  */
+    "\taaa", sbhand, 1, 1,	/* 0x37  */
+    CMP, aohand, 2, 4,		/* 0x38  */
+    CMP, aohand, 2, 4,		/* 0x39  */
+    CMP, aohand, 2, 4,		/* 0x3a  */
+    CMP, aohand, 2, 4,		/* 0x3b  */
+    CMP, aohand, 2, 2,		/* 0x3c  */
+    CMP, aohand, 3, 3,		/* 0x3d  */
+    "\tseg\tds", sbhand, 1, 1,	/* 0x3e  */
+    "\taas", sbhand, 1, 1,	/* 0x3f  */
+    "\tinc\tax", sbhand, 1, 1,	/* 0x40  */
+    "\tinc\tcx", sbhand, 1, 1,	/* 0x41  */
+    "\tinc\tdx", sbhand, 1, 1,	/* 0x42  */
+    "\tinc\tbx", sbhand, 1, 1,	/* 0x43  */
+    "\tinc\tsp", sbhand, 1, 1,	/* 0x44  */
+    "\tinc\tbp", sbhand, 1, 1,	/* 0x45  */
+    "\tinc\tsi", sbhand, 1, 1,	/* 0x46  */
+    "\tinc\tdi", sbhand, 1, 1,	/* 0x47  */
+    "\tdec\tax", sbhand, 1, 1,	/* 0x48  */
+    "\tdec\tcx", sbhand, 1, 1,	/* 0x49  */
+    "\tdec\tdx", sbhand, 1, 1,	/* 0x4a  */
+    "\tdec\tbx", sbhand, 1, 1,	/* 0x4b  */
+    "\tdec\tsp", sbhand, 1, 1,	/* 0x4c  */
+    "\tdec\tbp", sbhand, 1, 1,	/* 0x4d  */
+    "\tdec\tsi", sbhand, 1, 1,	/* 0x4e  */
+    "\tdec\tdi", sbhand, 1, 1,	/* 0x4f  */
+    "\tpush\tax", sbhand, 1, 1,	/* 0x50  */
+    "\tpush\tcx", sbhand, 1, 1,	/* 0x51  */
+    "\tpush\tdx", sbhand, 1, 1,	/* 0x52  */
+    "\tpush\tbx", sbhand, 1, 1,	/* 0x53  */
+    "\tpush\tsp", sbhand, 1, 1,	/* 0x54  */
+    "\tpush\tbp", sbhand, 1, 1,	/* 0x55  */
+    "\tpush\tsi", sbhand, 1, 1,	/* 0x56  */
+    "\tpush\tdi", sbhand, 1, 1,	/* 0x57  */
+    "\tpop\tax", sbhand, 1, 1,	/* 0x58  */
+    "\tpop\tcx", sbhand, 1, 1,	/* 0x59  */
+    "\tpop\tdx", sbhand, 1, 1,	/* 0x5a  */
+    "\tpop\tbx", sbhand, 1, 1,	/* 0x5b  */
+    "\tpop\tsp", sbhand, 1, 1,	/* 0x5c  */
+    "\tpop\tbp", sbhand, 1, 1,	/* 0x5d  */
+    "\tpop\tsi", sbhand, 1, 1,	/* 0x5e  */
+    "\tpop\tdi", sbhand, 1, 1,	/* 0x5f  */
+    NULL, dfhand, 0, 0,		/* 0x60  */
+    NULL, dfhand, 0, 0,		/* 0x61  */
+    NULL, dfhand, 0, 0,		/* 0x62  */
+    NULL, dfhand, 0, 0,		/* 0x63  */
+    "\tseg\tfs", sbhand, 1, 1,	/* 0x64  */
+    "\tseg\tgs", sbhand, 1, 1,	/* 0x65  */
+    "\tuse\top32", sbhand, 1, 1,	/* 0x66  */
+    "\tuse\tadr32", sbhand, 1, 1,	/* 0x67  */
+    "\tpush\t", mihand, 3, 3,	/* 0x68  */
+#if 0
+    NULL, dfhand, 0, 0,		/* 0x68  */
+#endif
+    NULL, dfhand, 0, 0,		/* 0x69  */
+    "\tpush\t", mihand, 2, 2,	/* 0x6a  */
+#if 0
+    NULL, dfhand, 0, 0,		/* 0x6a  */
+#endif
+    NULL, dfhand, 0, 0,		/* 0x6b  */
+    NULL, dfhand, 0, 0,		/* 0x6c  */
+    NULL, dfhand, 0, 0,		/* 0x6d  */
+    NULL, dfhand, 0, 0,		/* 0x6e  */
+    NULL, dfhand, 0, 0,		/* 0x6f  */
+    "\tjo", sjhand, 2, 2,	/* 0x70  */
+    "\tjno", sjhand, 2, 2,	/* 0x71  */
+    "\tjc", sjhand, 2, 2,	/* 0x72  */
+    "\tjnc", sjhand, 2, 2,	/* 0x73  */
+    "\tjz", sjhand, 2, 2,	/* 0x74  */
+    "\tjnz", sjhand, 2, 2,	/* 0x75  */
+    "\tjna", sjhand, 2, 2,	/* 0x76  */
+    "\tja", sjhand, 2, 2,	/* 0x77  */
+    "\tjs", sjhand, 2, 2,	/* 0x78  */
+    "\tjns", sjhand, 2, 2,	/* 0x79  */
+    "\tjp", sjhand, 2, 2,	/* 0x7a  */
+    "\tjnp", sjhand, 2, 2,	/* 0x7b  */
+    "\tjl", sjhand, 2, 2,	/* 0x7c  */
+    "\tjnl", sjhand, 2, 2,	/* 0x7d  */
+    "\tjng", sjhand, 2, 2,	/* 0x7e  */
+    "\tjg", sjhand, 2, 2,	/* 0x7f  */
+    AMBIG, imhand, 3, 5,	/* 0x80  */
+    AMBIG, imhand, 4, 6,	/* 0x81  */
+    AMBIG, imhand, 3, 5,	/* 0x82  */
+    AMBIG, imhand, 3, 5,	/* 0x83  */
+    TEST, mvhand, 2, 4,		/* 0x84  */
+    TEST, mvhand, 2, 4,		/* 0x85  */
+    "\txchg", mvhand, 2, 4,	/* 0x86  */
+    "\txchg", mvhand, 2, 4,	/* 0x87  */
+    MOV, mvhand, 2, 4,		/* 0x88  */
+    MOV, mvhand, 2, 4,		/* 0x89  */
+    MOV, mvhand, 2, 4,		/* 0x8a  */
+    MOV, mvhand, 2, 4,		/* 0x8b  */
+    MOV, mshand, 2, 4,		/* 0x8c  */
+    "\tlea", mvhand, 2, 4,	/* 0x8d  */
+    MOV, mshand, 2, 4,		/* 0x8e  */
+    "\tpop", pohand, 2, 4,	/* 0x8f  */
+    "\tnop", sbhand, 1, 1,	/* 0x90  */
+    "\txchg\tax,cx", sbhand, 1, 1,	/* 0x91  */
+    "\txchg\tax,dx", sbhand, 1, 1,	/* 0x92  */
+    "\txchg\tax,bx", sbhand, 1, 1,	/* 0x93  */
+    "\txchg\tax,sp", sbhand, 1, 1,	/* 0x94  */
+    "\txchg\tax,bp", sbhand, 1, 1,	/* 0x95  */
+    "\txchg\tax,si", sbhand, 1, 1,	/* 0x96  */
+    "\txchg\tax,di", sbhand, 1, 1,	/* 0x97  */
+    "\tcbw", sbhand, 1, 1,	/* 0x98  */
+    "\tcwd", sbhand, 1, 1,	/* 0x99  */
+    "\tcalli", cihand, 5, 5,	/* 0x9a  */
+    "\twait", sbhand, 1, 1,	/* 0x9b  */
+    "\tpushf", sbhand, 1, 1,	/* 0x9c  */
+    "\tpopf", sbhand, 1, 1,	/* 0x9d  */
+    "\tsahf", sbhand, 1, 1,	/* 0x9e  */
+    "\tlahf", sbhand, 1, 1,	/* 0x9f  */
+    MOV, mqhand, 3, 3,		/* 0xa0  */
+    MOV, mqhand, 3, 3,		/* 0xa1  */
+    MOV, mqhand, 3, 3,		/* 0xa2  */
+    MOV, mqhand, 3, 3,		/* 0xa3  */
+    "\tmovb", sbhand, 1, 1,	/* 0xa4  */
+    "\tmovw", sbhand, 1, 1,	/* 0xa5  */
+    "\tcmpb", sbhand, 1, 1,	/* 0xa6  */
+    "\tcmpw", sbhand, 1, 1,	/* 0xa7  */
+    TEST, tqhand, 2, 2,		/* 0xa8  */
+    TEST, tqhand, 3, 3,		/* 0xa9  */
+    "\tstob", sbhand, 1, 1,	/* 0xaa  */
+    "\tstow", sbhand, 1, 1,	/* 0xab  */
+    "\tlodb", sbhand, 1, 1,	/* 0xac  */
+    "\tlodw", sbhand, 1, 1,	/* 0xad  */
+    "\tscab", sbhand, 1, 1,	/* 0xae  */
+    "\tscaw", sbhand, 1, 1,	/* 0xaf  */
+    "\tmov\tal,", mihand, 2, 2,	/* 0xb0  */
+    "\tmov\tcl,", mihand, 2, 2,	/* 0xb1  */
+    "\tmov\tdl,", mihand, 2, 2,	/* 0xb2  */
+    "\tmov\tbl,", mihand, 2, 2,	/* 0xb3  */
+    "\tmov\tah,", mihand, 2, 2,	/* 0xb4  */
+    "\tmov\tch,", mihand, 2, 2,	/* 0xb5  */
+    "\tmov\tdh,", mihand, 2, 2,	/* 0xb6  */
+    "\tmov\tbh,", mihand, 2, 2,	/* 0xb7  */
+    "\tmov\tax,", mihand, 3, 3,	/* 0xb8  */
+    "\tmov\tcx,", mihand, 3, 3,	/* 0xb9  */
+    "\tmov\tdx,", mihand, 3, 3,	/* 0xba  */
+    "\tmov\tbx,", mihand, 3, 3,	/* 0xbb  */
+    "\tmov\tsp,", mihand, 3, 3,	/* 0xbc  */
+    "\tmov\tbp,", mihand, 3, 3,	/* 0xbd  */
+    "\tmov\tsi,", mihand, 3, 3,	/* 0xbe  */
+    "\tmov\tdi,", mihand, 3, 3,	/* 0xbf  */
+    NULL, dfhand, 0, 0,		/* 0xc0  */
+    NULL, dfhand, 0, 0,		/* 0xc1  */
+    "\tret", rehand, 3, 3,	/* 0xc2  */
+    "\tret", sbhand, 1, 1,	/* 0xc3  */
+    "\tles", mvhand, 2, 4,	/* 0xc4  */
+    "\tlds", mvhand, 2, 4,	/* 0xc5  */
+    MOV, mmhand, 3, 5,		/* 0xc6  */
+    MOV, mmhand, 4, 6,		/* 0xc7  */
+    NULL, dfhand, 0, 0,		/* 0xc8  */
+    NULL, dfhand, 0, 0,		/* 0xc9  */
+#if 0
+    /* MJG: this should be retf */
+    "\treti", rehand, 3, 3,	/* 0xca  */
+#endif
+    "\tretf", rehand, 3, 3,	/* 0xca  */
+    "\tretf", sbhand, 1, 1,	/* 0xcb  */
+    "\tint", sbhand, 1, 1,	/* 0xcc  */
+    "\tint", inhand, 2, 2,	/* 0xcd  */
+    "\tinto", sbhand, 1, 1,	/* 0xce  */
+    "\tiret", sbhand, 1, 1,	/* 0xcf  */
+    AMBIG, srhand, 2, 4,	/* 0xd0  */
+    AMBIG, srhand, 2, 4,	/* 0xd1  */
+    AMBIG, srhand, 2, 4,	/* 0xd2  */
+    AMBIG, srhand, 2, 4,	/* 0xd3  */
+    "\taam", aahand, 2, 2,	/* 0xd4  */
+    "\taad", aahand, 2, 2,	/* 0xd5  */
+    NULL, dfhand, 0, 0,		/* 0xd6  */
+    "\txlat", sbhand, 1, 1,	/* 0xd7  */
+    ESC, eshand, 2, 2,		/* 0xd8  */
+    ESC, eshand, 2, 2,		/* 0xd9  */
+    ESC, eshand, 2, 2,		/* 0xda  */
+    ESC, eshand, 2, 2,		/* 0xdb  */
+    ESC, eshand, 2, 2,		/* 0xdc  */
+    ESC, eshand, 2, 2,		/* 0xdd  */
+    ESC, eshand, 2, 2,		/* 0xde  */
+    ESC, eshand, 2, 2,		/* 0xdf  */
+    "\tloopne", sjhand, 2, 2,	/* 0xe0  */
+    "\tloope", sjhand, 2, 2,	/* 0xe1  */
+    "\tloop", sjhand, 2, 2,	/* 0xe2  */
+    "\tjcxz", sjhand, 2, 2,	/* 0xe3  */
+    "\tin", iohand, 2, 2,	/* 0xe4  */
+    "\tinw", iohand, 2, 2,	/* 0xe5  */
+    "\tout", iohand, 2, 2,	/* 0xe6  */
+    "\toutw", iohand, 2, 2,	/* 0xe7  */
+    "\tcall", ljhand, 3, 3,	/* 0xe8  */
+    "\tjmp", ljhand, 3, 3,	/* 0xe9  */
+    "\tjmpi", cihand, 5, 5,	/* 0xea  */
+    "\tj", sjhand, 2, 2,	/* 0xeb  */
+    "\tin", sbhand, 1, 1,	/* 0xec  */
+    "\tinw", sbhand, 1, 1,	/* 0xed  */
+    "\tout", sbhand, 1, 1,	/* 0xee  */
+    "\toutw", sbhand, 1, 1,	/* 0xef  */
+    "\tlock", sbhand, 1, 1,	/* 0xf0  */
+    NULL, dfhand, 0, 0,		/* 0xf1  */
+    "\trepnz", sbhand, 1, 1,	/* 0xf2  */
+    "\trepz", sbhand, 1, 1,	/* 0xf3  */
+    "\thlt", sbhand, 1, 1,	/* 0xf4  */
+    "\tcmc", sbhand, 1, 1,	/* 0xf5  */
+    AMBIG, mahand, 2, 5,	/* 0xf6  */
+    AMBIG, mahand, 2, 6,	/* 0xf7  */
+    "\tclc", sbhand, 1, 1,	/* 0xf8  */
+    "\tstc", sbhand, 1, 1,	/* 0xf9  */
+    "\tcli", sbhand, 1, 1,	/* 0xfa  */
+    "\tsti", sbhand, 1, 1,	/* 0xfb  */
+    "\tcld", sbhand, 1, 1,	/* 0xfc  */
+    "\tstd", sbhand, 1, 1,	/* 0xfd  */
+    AMBIG, mjhand, 2, 4,	/* 0xfe  */
+    AMBIG, mjhand, 2, 4		/* 0xff  */
+};
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This simple routine  returns the name field of a symbol *
+  * table entry as a printable string.                      *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+char *getnam(register int k)
+{				/* * * * * * * * * *  START OF getnam()  * * * * * * * * * */
+
+    static char a[sizeof(symtab->n_name) + 1];
+    register int j;
+
+    for (j = 0; j < sizeof(symtab[k].n_name); ++j)
+	if (!symtab[k].n_name[j])
+	    break;
+	else
+	    a[j] = symtab[k].n_name[j];
+
+    a[j] = '\0';
+
+    return a;
+
+}				/* * * * * * * * * * * END OF getnam() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This function is  responsible  for mucking  through the *
+  * relocation  table in  search of  externally  referenced *
+  * symbols to be output as  operands.  It accepts two long *
+  * arguments: the code-segment location at which an extern *
+  * reference  is  expected,  and the offset value which is *
+  * embedded  in the  object  code and used at link time to *
+  * bias the external value.  In the most typical case, the *
+  * function will be called by lookup(), which always makes *
+  * a check for external names before  searching the symbol *
+  * table proper.  However,  it may also be called directly *
+  * by any function  (such as the  move-immediate  handler) *
+  * which wants to make an independent check for externals. *
+  * The caller is expected to supply, as the third argument *
+  * to the function,  a pointer to a character buffer large *
+  * enough to hold any possible  output  string.  Lookext() *
+  * will fill this  buffer and return a logical  TRUE if it *
+  * finds an extern reference;  otherwise, it will return a *
+  * logical FALSE, leaving the buffer undisturbed.          *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int lookext(long off, long loc, char *buf)
+{				/* * * * * * * * * * START OF  lookext() * * * * * * * * * */
+
+    char c[32];
+    register int k;
+
+    if ((loc != -1L) && (relptr >= 0))
+	for (k = 0; k <= relptr; ++k)
+	    if ((relo[k].r_vaddr == loc)
+		&& (relo[k].r_symndx < S_BSS)) {
+		strcpy(buf, getnam(relo[k].r_symndx));
+		if (off) {
+		    if (off < 0)
+			sprintf(c, "%ld", off);
+		    else
+			sprintf(c, "+%ld", off);
+		    strcat(buf, c);
+		}
+		return 1;
+	    }
+
+    return 0;
+
+}				/* * * * * * * * * *  END OF  lookext()  * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This  function  finds an entry in the  symbol  table by *
+  * value.  Its input is a (long) machine address,  and its *
+  * output is a pointer to a string  containing  the corre- *
+  * sponding symbolic name. The function first searches the *
+  * relocation table for a possible external reference;  if *
+  * none is found,  a linear  search of the symbol table is *
+  * undertaken. If no matching symbol has been found at the *
+  * end of these searches,  the function  returns a pointer *
+  * to a string  containing the ASCII equivalent of the ad- *
+  * dress which was to be located,  so that,  regardless of *
+  * the success of the search,  the function's return value *
+  * is suitable for use as a memory-reference operand.  The *
+  * caller specifies the type of symbol to be found  (text, *
+  * data, bss, undefined,  absolute, or common) by means of *
+  * the function's  second  parameter.  The third parameter *
+  * specifies  the  format to be used in the event of a nu- *
+  * meric output:  zero for absolute format,  one for short *
+  * relative  format,  two for long  relative  format.  The *
+  * fourth  parameter is the address  which would appear in *
+  * the relocation table for the reference in question,  or *
+  * -1 if the relocation  table is not to be searched.  The *
+  * function attempts to apply a certain amount of intelli- *
+  * gence in its  selection  of symbols,  so it is possible *
+  * that,  in the absence of a type match,  a symbol of the *
+  * correct value but different type will be returned.      *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+char *lookup(long addr,		/* Machine address to be located */
+	     int type,		/* Type of symbol to be matched  */
+	     int kind,		/* Addressing output mode to use */
+	     long ext)
+{				/* Value for extern ref, if any  *//* * * * * * * * * *  START OF lookup()  * * * * * * * * * */
+
+    static char b[80];
+    register int j, k;
+
+    struct {
+	int i;
+	int t;
+    } best;
+
+    if (lookext(addr, ext, b))
+	return b;
+
+    if (segflg)
+	if (segflg & 1)
+	    type = N_TEXT;
+	else
+	    type = N_DATA;
+
+    for (k = 0, best.i = -1; k <= symptr; ++k)
+	if (symtab[k].n_value == addr)
+	    if ((j = symtab[k].n_sclass & N_SECT) == type) {
+		best.t = j;
+		best.i = k;
+		break;
+	    }
+    /*else if (segflg || (HDR.a_flags & A_SEP)) */
+	    else if (segflg)	/* Assume (HDR.a_flags & A_SEP)) true */
+		continue;
+	    else if (best.i < 0)
+		best.t = j, best.i = k;
+	    else if (symrank[type][j] > symrank[type][best.t])
+		best.t = j, best.i = k;
+
+    if (best.i >= 0)
+	return getnam(best.i);
+
+    if (kind == LOOK_ABS)
+	sprintf(b, "$%04lx", addr);
+    else {
+	long x = addr - (PC - kind);
+	if (x < 0)
+	    sprintf(b, ".%ld", x);
+	else
+	    sprintf(b, ".+%ld", x);
+    }
+
+    return b;
+
+}				/* * * * * * * * * * * END OF lookup() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This function  translates an 8088  addressing mode byte *
+  * to an equivalent assembler string,  returning a pointer *
+  * thereto.  If necessary,  it performs  successive inputs *
+  * of bytes from the object file in order to obtain offset *
+  * data,  adjusting PC  accordingly.  (The addressing mode *
+  * byte  appears in several  8088  opcodes;  it is used to *
+  * specify source and destination operand locations.)  The *
+  * third  argument to the function is zero if the standard *
+  * registers are to be used,  or eight if the segment reg- *
+  * isters are to be used; these constants are defined sym- *
+  * bolically in dis.h.  NOTE:  The mtrans()  function must *
+  * NEVER be called except  immediately  after fetching the *
+  * mode byte.  If any additional  object bytes are fetched *
+  * after  the fetch of the mode  byte,  mtrans()  will not *
+  * produce correct output!                                 *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#undef FRV
+#define FRV ""
+
+char *mtrans(register int c,	/* Primary instruction byte   */
+	     register int m,	/* Addressing mode byte       */
+	     int type)
+{				/* Type code: standard or seg *//* * * * * * * * * *  START OF mtrans()  * * * * * * * * * */
+
+    static char a[128], b[32];
+    unsigned long pc;
+    int offset, oflag, dir, w, mod, reg, rm;
+
+    offset = 0;
+    dir = c & 2;
+    w = c & 1;
+    mod = (m & 0xc0) >> 6;
+    reg = (m & 0x38) >> 3;
+    rm = m & 7;
+    pc = PC + 1;
+
+    if (type)
+	w = 1;
+
+    if ((oflag = mod) > 2)
+	oflag = 0;
+
+    if (oflag) {
+	int j, k;
+	if (oflag == 2) {
+	    FETCH(j);
+	    FETCH(k);
+	    offset = (k << 8) | j;
+	} else {
+	    FETCH(j);
+	    if (j & 0x80)
+		k = 0xff00;
+	    else
+		k = 0;
+	    offset = k | j;
+	}
+    }
+
+    if (dir) {
+	strcpy(a, REGS[type + ((w << 3) | reg)]);
+	strcat(a, ",");
+	switch (mod) {
+	case 0:
+	    if (rm == 6) {
+		int j, k;
+		FETCH(j);
+		FETCH(k);
+		offset = (k << 8) | j;
+		strcat(a, lookup((long) (offset), N_DATA, LOOK_ABS, pc));
+	    } else {
+		sprintf(b, "(%s)", REGS0[rm]);
+		strcat(a, b);
+	    }
+	    break;
+	case 1:
+	case 2:
+	    if (mod == 1)
+		strcat(a, "*");
+	    else
+		strcat(a, "#");
+	    sprintf(b, "%d(", (short) offset);
+	    strcat(a, b);
+	    strcat(a, REGS1[rm]);
+	    strcat(a, ")");
+	    break;
+	case 3:
+	    strcat(a, REGS[(w << 3) | rm]);
+	    break;
+	}
+    } else {
+	switch (mod) {
+	case 0:
+	    if (rm == 6) {
+		int j, k;
+		FETCH(j);
+		FETCH(k);
+		offset = (k << 8) | j;
+		strcpy(a, lookup((long) (offset), N_DATA, LOOK_ABS, pc));
+	    } else {
+		sprintf(b, "(%s)", REGS0[rm]);
+		strcpy(a, b);
+	    }
+	    break;
+	case 1:
+	case 2:
+	    if (mod == 1)
+		strcpy(a, "*");
+	    else
+		strcpy(a, "#");
+	    sprintf(b, "%d(", (short) offset);
+	    strcat(a, b);
+	    strcat(a, REGS1[rm]);
+	    strcat(a, ")");
+	    break;
+	case 3:
+	    strcpy(a, REGS[(w << 3) | rm]);
+	    break;
+	}
+	strcat(a, ",");
+	strcat(a, REGS[type + ((w << 3) | reg)]);
+    }
+
+    return a;
+
+}				/* * * * * * * * * * * END OF mtrans() * * * * * * * * * * */
+
+ /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+  *                                                         *
+  * This simple routine  truncates a string returned by the *
+  * mtrans() function, removing its source operand. This is *
+  * useful in handlers which ignore the "reg"  field of the *
+  * mode byte.                                              *
+  *                                                         *
+  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void mtrunc(register char *a)
+{				/* Ptr. to string to truncate *//* * * * * * * * * *  START OF mtrunc()  * * * * * * * * * */
+
+    register int k;
+
+    for (k = strlen(a) - 1; k >= 0; --k)
+	if (a[k] == ',') {
+	    a[k] = '\0';
+	    break;
+	}
+
+}				/* * * * * * * * * * * END OF mtrunc() * * * * * * * * * * */
+

--- a/emu86/.gitignore
+++ b/emu86/.gitignore
@@ -3,5 +3,4 @@ pcat
 
 emu86.pts
 
-test-pt1-out.txt
 test-mon86-out.txt

--- a/emu86/test-pt1
+++ b/emu86/test-pt1
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-./emu86 -w 0xf0000 -f ../mon86/pt1.bin -x 0xf000:0x0 &
-
-sleep 1
-
-./pcat `cat emu86.pts` <../mon86/test-pt1-in.txt >test-pt1-out.txt
-
-diff ../mon86/test-pt1-ref.txt test-pt1-out.txt

--- a/mon86/test-mon86-target
+++ b/mon86/test-mon86-target
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Test MON86 on real target
+
+../emu86/pcat /dev/ttyUSB0 < test-mon86-in.txt > test-mon86-out.txt
+
+diff test-mon86-ref.txt test-mon86-out.txt


### PR DESCRIPTION
This pull request contains:
* the moved DIS88 code from ELKS side
* EMU86 cleanup after MON86 first release
* EMU86 new option to run program in tiny model

Moved DIS88 is kept "as is", until a decision to maintain this tool or to remove it & replace by the new DIS86 that is currently incubating inside EMU86.

EMU86 tested with NE2K standalone test program from ELKS.
