### PR TITLE
Make dev86 working "in tree"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ copt/copt
 cpp/bcc-cpp
 
 ifdefg
+
+include
+
 ld/ar.h
 ld/ld86
 ld/objdump86
@@ -134,8 +137,6 @@ lib/
 libc/error/error_list.h
 libc/i386sys/syscall.c
 libc/i386sys/syscall.mak
-libc/include/arch
-libc/include/linuxmt
 libc/include/malloc.h
 libc/include/regexp.h
 libc/include/regmagic.h

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ make.fil: $(IFDEFNAME) makefile.in
 	./$(IFDEFNAME) -MU $(IFDEFOPTS) makefile.in >tmp.mak
 	echo > tmp.sed
 	[ "$(BINDIR)" != "//bin" ] || echo >> tmp.sed "s:%BINDIR%:/bin:"
-	[ "$(LIBDIR)" != "//lib/bcc" ] || echo >> tmp.sed "s:%LIBDIR%:/lib:"
-	[ "$(INCLDIR)" != "//lib/bcc" ] || echo >> tmp.sed "s:%INCLDIR%:/usr:"
+	[ "$(LIBDIR)" != "//lib/bcc" ] || echo >> tmp.sed "s:%LIBDIR%:/lib/bcc:"
+	[ "$(INCLDIR)" != "//lib/bcc" ] || echo >> tmp.sed "s:%INCLDIR%:/lib/bcc:"
 	[ "$(ASLDDIR)" != "//bin" ] || echo >> tmp.sed "s:%ASLDDIR%:/bin:"
-	[ "$(MANDIR)" != "//man" ] || echo >> tmp.sed "s:%MANDIR%:/usr/man:"
+	[ "$(MANDIR)" != "//man" ] || echo >> tmp.sed "s:%MANDIR%:/man:"
 	echo >> tmp.sed "s:%PREFIX%:$(PREFIX):"
 	echo >> tmp.sed "s:%BINDIR%:$(BINDIR):"
 	echo >> tmp.sed "s:%INCLDIR%:$(INCLDIR):"

--- a/bcc/bcc.c
+++ b/bcc/bcc.c
@@ -223,12 +223,12 @@ char ** argv;
 #endif
       } else {
 	 /* Relative paths to a build dir "-M-" */
-	 build_prefix("/lib", libdir_suffix, "");
-	 build_prefix("/lib", "", "");
+	 build_prefix("/lib/bcc", libdir_suffix, "");
+	 build_prefix("/lib/bcc", "", "");
 
 	 default_include = build_libpath("-I", "/include", "");
 	 default_libdir  = build_libpath("-L", "/lib", libdir_suffix);
-	 optim_rules     = build_libpath("-d", "/lib", libdir_suffix);
+	 optim_rules     = build_libpath("-d", "/lib/bcc", libdir_suffix);
       }
 
    } else {
@@ -440,7 +440,7 @@ struct file_list * file;
    switch(opt_arch) {
    case 0: command_opt("rules.86"); break;
    case 1: 
-   case 2: command_opt("rules.i386"); break;
+   case 2: command_opt("rules.386"); break;
    case 4: command_opt("rules.6809"); break;
    default:command_opt("rules.mid"); break;
    }

--- a/include
+++ b/include
@@ -1,1 +1,0 @@
-libc/include

--- a/libbsd/Make.defs
+++ b/libbsd/Make.defs
@@ -45,7 +45,7 @@ ARCH=-3
 endif
 
 CC=bcc $(ARCH)
-CCFLAGS=-O -I -I$(TOP)/libc/include
+CCFLAGS=-O -I -I$(TOP)/libc/include -I$(TOP)/libc/kinclude
 LKFLAGS=-L -L$(TOP)/ -s
 
 else # ifeq ($(PLATFORM),i386-Linux)

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -11,7 +11,7 @@ endif
 
 LIBBCC=$(TOP)/libbcc.a
 CC=bcc
-CCFLAGS=-I -I$(TOP)/include
+CCFLAGS=-O -I -I$(TOP)/include -I$(TOP)/kinclude
 DEFS=-D__LIBC__
 
 include Make.defs
@@ -62,10 +62,6 @@ transfer: .config.dir
 	@for i in `cat .config.dir`; do \
 	   grep -s '^transfer' $$i/Makefile && $(MAKE) -s -C $$i $@ ; \
 	done ; echo -n
-	@[ -d include/linuxmt/. ] || \
-	  ln -s $(ELKSSRC)/include/linuxmt include
-	@[ -d include/arch/. ] || \
-	  ln -s $(ELKSSRC)/include/arch include
 
 ############################################################################
 
@@ -81,7 +77,6 @@ clean:
 
 install_incl: transfer
 	install -d $(DISTINCL)/include
-	rm -f $(DISTINCL)/include/linuxmt $(DISTINCL)/include/arch ||:
 	cp -LpR include/* $(DISTINCL)/include
 	-chown -R $(USERID):$(GROUPID) $(DISTINCL)/include
 	-chmod -R ugo-x,u=rwX,og=rX $(DISTINCL)/include

--- a/libc/kinclude/Makefile
+++ b/libc/kinclude/Makefile
@@ -6,9 +6,5 @@ all:
 	@:
 
 transfer:
-	-@rm -f ../include/linuxmt ../include/arch
-	ln -s ../kinclude/linuxmt ../include
-	ln -s ../kinclude/arch ../include
 
 clean:
-	-rm -f ../include/linuxmt ../include/arch

--- a/makefile.in
+++ b/makefile.in
@@ -114,7 +114,7 @@ install install-all: check_config install-bcc install-man
 
 ##############################################################################
 
-LIBARGS= CC=ncc "CCFLAGS=-O" AR=$(AR) ARFLAGS=$(ARFLAGS)
+LIBARGS= CC=ncc AR=$(AR) ARFLAGS=$(ARFLAGS)
 LIB3ARGS= CC=ncc AR=$(AR) ARFLAGS=$(ARFLAGS)
 
 # Season in the top makefile
@@ -143,41 +143,36 @@ CLEANLIST= bcc as ar ld cpp unproto copt libc elksemu libbsd $(OTHERS)
 ##############################################################################
 
 bindir: $(MAKEX)
-	@mkdir -p bin lib lib/i386
+	@mkdir -p bin lib lib/i386 lib/bcc lib/bcc/i386
 	@rm -f include
 	@ln -s libc/include include 2>/dev/null || true
-#ifndef GNUMAKE
-	@rm -f include/linuxmt include/arch || true
-	@ln -s ../kinclude/linuxmt include/linuxmt 2>/dev/null || true
-	@ln -s ../kinclude/arch    include/arch    2>/dev/null || true
-#endif
 
 bcc86: bindir versions
 	$(MAKEC) bcc $(MAKEARG) BCCARCH='$(BCCARCH)' bcc ncc bcc-cc1
-	cp -p bcc/bcc$(EXE) bin/Bcc$(EXE)
+	cp -p bcc/bcc$(EXE) bin/bcc$(EXE)
 	cp -p bcc/ncc$(EXE) bin/ncc$(EXE)
-	cp -p bcc/bcc-cc1$(EXE) lib/bcc-cc1$(EXE)
+	cp -p bcc/bcc-cc1$(EXE) lib/bcc/bcc-cc1$(EXE)
 
 cpp:  bindir
 	$(MAKEC) cpp $(MAKEARG) bcc-cpp
-	cp -p cpp/bcc-cpp$(EXE) lib/bcc-cpp$(EXE)
+	cp -p cpp/bcc-cpp$(EXE) lib/bcc/bcc-cpp$(EXE)
 
 unproto:  bindir
 	$(MAKEC) unproto $(MAKEARG) unproto
-	cp -p unproto/unproto$(EXE) lib/unproto$(EXE)
+	cp -p unproto/unproto$(EXE) lib/bcc/unproto$(EXE)
 
 copt:  bindir
 	$(MAKEC) copt $(MAKEARG) copt
-	cp -p copt/copt$(EXE) lib/copt$(EXE)
-	cp -p copt/rules.* lib/.
-	cp -p copt/rules.start lib/i386/.
-	cp -p copt/rules.386 lib/i386/.
-	cp -p copt/rules.end lib/i386/.
+	cp -p copt/copt$(EXE) lib/bcc/copt$(EXE)
+	cp -p copt/rules.* lib/bcc/.
+	cp -p copt/rules.start lib/bcc/i386/.
+	cp -p copt/rules.386 lib/bcc/i386/.
+	cp -p copt/rules.end lib/bcc/i386/.
 
 as86: bindir versions
 	$(MAKEC) as $(MAKEARG) all
 	cp -p as/as86$(EXE) bin/as86$(EXE)
-	cp -p as/as86_encap bin/as86_encap
+	cp -p as/as86_encap lib/bcc/as86_encap
 
 ar86: bindir
 	$(MAKEC) ar $(MAKEARG) all
@@ -209,21 +204,21 @@ try_elksemu: bindir
 
 install-bcc: bcc86 cpp unproto copt as86 ar86 ld86 objdump86
 	install -d $(DISTBIN) $(DISTLIB)
-	install $(INEXE) bin/Bcc$(EXE) 		$(DISTBIN)/bcc$(EXE)
+	install $(INEXE) bin/bcc$(EXE) 		$(DISTBIN)/bcc$(EXE)
 	install $(INEXE) bin/as86$(EXE) 	$(DISTASLD)/as86$(EXE)
 	install $(INEXE) bin/ld86$(EXE) 	$(DISTASLD)/ld86$(EXE)
 	install $(INEXE) bin/ar86$(EXE) 	$(DISTBIN)/ar86$(EXE)
 	install $(INEXE) bin/objdump86$(EXE) 	$(DISTBIN)/objdump86$(EXE)
 	install $(INEXE) bin/objdump86$(EXE) 	$(DISTBIN)/nm86$(EXE)
 	install $(INEXE) bin/objdump86$(EXE) 	$(DISTBIN)/size86$(EXE)
-	install $(INSCR) bin/as86_encap		$(DISTLIB)/as86_encap
-	install $(INEXE) lib/bcc-cc1$(EXE) 	$(DISTLIB)/bcc-cc1$(EXE)
-	install $(INEXE) lib/bcc-cpp$(EXE) 	$(DISTLIB)/bcc-cpp$(EXE)
-	install $(INEXE) lib/unproto$(EXE) 	$(DISTLIB)/unproto$(EXE)
-	install $(INEXE) lib/copt$(EXE) 	$(DISTLIB)/copt$(EXE)
-	install $(INDAT) lib/rules.* 		$(DISTLIB)
+	install $(INSCR) lib/bcc/as86_encap		$(DISTLIB)/as86_encap
+	install $(INEXE) lib/bcc/bcc-cc1$(EXE) 	$(DISTLIB)/bcc-cc1$(EXE)
+	install $(INEXE) lib/bcc/bcc-cpp$(EXE) 	$(DISTLIB)/bcc-cpp$(EXE)
+	install $(INEXE) lib/bcc/unproto$(EXE) 	$(DISTLIB)/unproto$(EXE)
+	install $(INEXE) lib/bcc/copt$(EXE) 	$(DISTLIB)/copt$(EXE)
+	install $(INDAT) lib/bcc/rules.*		$(DISTLIB)
 	install -d $(DISTLIB)/i386
-	install $(INDAT) lib/i386/rules.* 	$(DISTLIB)/i386
+	install $(INDAT) lib/bcc/i386/rules.* 	$(DISTLIB)/i386
 
 # NB: This doesn't install as a suid root, that's ok though.
 install-emu: elksemu

--- a/mon86/Makefile
+++ b/mon86/Makefile
@@ -20,3 +20,6 @@ mon86-stub.o : mon86-target.c
 mon86-stub : mon86-common-host.o mon86-stub.o
 
 mon86-host : mon86-common-host.o mon86-host.o
+
+clean:
+	-rm *.o mon86-stub mon86-host


### PR DESCRIPTION
Tune the build of `dev86` to make it working "in tree" without installing (put some BCC executables and `rules.*` in /lib/bcc rather than in /lib), and do not mix ELKS and C library headers (keep local copy of /linuxmt and /arch insulated in /kinclude).

Using the `PREFIX` variable is still needed (`make PREFIX=<tree root folder>`) for BCC to chain correctly the sub-programs.

This is a prerequisite for jbruchon/elks#191.