### PR TITLE
build: Always use $(MAKE) to spawn sub-make

### DIFF
--- a/bootblocks/Makefile
+++ b/bootblocks/Makefile
@@ -55,31 +55,31 @@ fs_min.o: minix.h
 
 bootfile.sys: $(MSRC) $(MINC)
 	@rm -f $(MOBJ)
-	make 'CFLAGS=$(CFLAGS) -DDOSFLOPPY' monitor.out
+	$(MAKE) 'CFLAGS=$(CFLAGS) -DDOSFLOPPY' monitor.out
 	mv monitor.out bootfile.sys
 	@rm -f $(MOBJ)
 
 boottar.sys: $(MSRC) $(MINC) tarboot.bin
 	@rm -f $(MOBJ)
-	make 'CFLAGS=$(CFLAGS) -DTARFLOPPY' monitor.out
+	$(MAKE) 'CFLAGS=$(CFLAGS) -DTARFLOPPY' monitor.out
 	mv monitor.out boottar.sys
 	@rm -f $(MOBJ)
 
 bootminix.sys: $(MSRC) $(MINC) minix.bin
 	@rm -f $(MOBJ)
-	make 'CFLAGS=$(CFLAGS) -DMINFLOPPY' monitor.out
+	$(MAKE) 'CFLAGS=$(CFLAGS) -DMINFLOPPY' monitor.out
 	mv monitor.out bootminix.sys
 	@rm -f $(MOBJ)
 
 monitor.sys: $(MSRC) $(MINC)
 	@rm -f $(MOBJ)
-	make monitor.out
+	$(MAKE) monitor.out
 	mv monitor.out monitor.sys
 	@rm -f $(MOBJ)
 
 monitor: $(MSRC) $(MINC)
 	@rm -f $(MOBJ)
-	make 'CFLAGS=-ansi $(DEFS)' monitor.out
+	$(MAKE) 'CFLAGS=-ansi $(DEFS)' monitor.out
 	mv monitor.out monitor
 	@rm -f $(MOBJ)
 

--- a/libbsd/Makefile
+++ b/libbsd/Makefile
@@ -29,7 +29,7 @@ install: all
 	install -m 644 $(LIBBSD) $(LIBDIR)/i86
 
 tests: dummy
-	make -C tests
+	$(MAKE) -C tests
 
 $(LIBBSD): $(OBJS)
 	$(AR) rc $(LIBBSD) $(OBJS)

--- a/makefile.in
+++ b/makefile.in
@@ -326,7 +326,7 @@ config: ;
 #endif
 
 makec:
-	echo 'cd $$1 ; shift ; make "$$@"' > makec
+	echo 'cd $$1 ; shift ; $(MAKE) "$$@"' > makec
 	chmod +x makec
 
 versions: bcc/version.h


### PR DESCRIPTION
Always use $(MAKE) instead of literal 'make' to spawn the correct make
variant. Otherwise, e.g. when using 'gmake' on FreeBSD the Makefiles
spawn BSD make and things fail because of incompatible MAKEFLAGS
set by GNU make.

(moved from https://github.com/lkundrak/dev86/pull/17)