### PR TITLE
Add .travis.yml for running "make distribution" tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# https://travis-ci.org/
+language: c
+
+# Select Trusty
+dist: trusty
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - fakeroot
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - clang
+  - gcc
+
+script:
+  - CC="$CC -Wno-error=return-type" sh ./Mk_dist $(sed -n 's/^VERSION=\(.*\)/\1/p' Makefile )

--- a/dev86arc/.gitignore
+++ b/dev86arc/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/makefile.in
+++ b/makefile.in
@@ -342,12 +342,12 @@ bcc/version.h: Makefile
 
 install-other: other
 	@for i in $(OTHERS) ; do \
-		$(MAKEC) $$i BCC=ncc DIST=$(DIST) PREFIX=$(PREFIX) install || exit 1 ; \
+		$(MAKEC) $$i BCC=ncc DIST="$(DIST)" PREFIX="$(PREFIX)" install || exit 1 ; \
 	done
 
 other: versions
 	@for i in $(OTHERS) ; do \
-		$(MAKEC) $$i BCC=ncc DIST=$(DIST) PREFIX=$(PREFIX) || exit 1; \
+		$(MAKEC) $$i BCC=ncc HOSTCC="$(CC)" DIST="$(DIST)" PREFIX="$(PREFIX)" || exit 1; \
 	done
 
 ##############################################################################


### PR DESCRIPTION
Just a little problem; `make distribution` is falling.
This PR runs it on [travisci](https://travis-ci.org/rdebath/dev86).

<hr>
OSX does not have fakeroot, so we avoid it.
This will mean that the archive files aren't owned by root.

Also when testing with clang Mk_dist didn't pass it onto the tests. It now does so; this means we can work around clang's warnings that are sort of errors without actually fixing the code.