### PR TITLE
Modify elksemu implementation so that it also works on Linux/x86-64

### DIFF
--- a/cpp/token2.h
+++ b/cpp/token2.h
@@ -1,15 +1,47 @@
-/* C code produced by gperf version 2.7.1 (19981006 egcs) */
+/* C code produced by gperf version 3.0.4 */
 /* Command-line: gperf -aptTc -k1,3 -N is_ckey -H hash2 token2.tok  */
+
+#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
+      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
+      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
+      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
+      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
+      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
+      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
+      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
+      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
+      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
+      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
+      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
+      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
+      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
+      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
+      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
+      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
+      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
+      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
+      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
+      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
+/* The character set is not based on ISO-646.  */
+error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#endif
+
 
 #define TOTAL_KEYWORDS 34
 #define MIN_WORD_LENGTH 2
 #define MAX_WORD_LENGTH 8
-#define MIN_HASH_VALUE 2
-#define MAX_HASH_VALUE 69
-/* maximum key range = 68, duplicates = 0 */
+#define MIN_HASH_VALUE 3
+#define MAX_HASH_VALUE 44
+/* maximum key range = 42, duplicates = 0 */
 
 #ifdef __GNUC__
 __inline
+#else
+#ifdef __cplusplus
+inline
+#endif
 #endif
 static unsigned int
 hash2 (str, len)
@@ -18,40 +50,40 @@ hash2 (str, len)
 {
   static unsigned char asso_values[] =
     {
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-       5, 70, 70, 70, 70, 70,  0, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70,  0, 70,  5,  5, 10,
-      10, 20, 20, 25, 70,  0, 70, 70, 50, 70,
-       0, 15,  0, 70, 15,  0, 40, 20,  0,  0,
-      70, 70, 10, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70, 70, 70, 70, 70,
-      70, 70, 70, 70, 70, 70
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      25, 45, 45, 45, 45, 45, 10, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45,  5, 45, 30, 10, 10,
+      25, 20,  0, 10, 45,  5, 45, 45, 25, 45,
+      10, 10,  5, 45,  0,  5,  0,  0,  0, 20,
+      45, 45, 25, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45, 45, 45, 45, 45,
+      45, 45, 45, 45, 45, 45
     };
   register int hval = len;
 
   switch (hval)
     {
       default:
-      case 3:
         hval += asso_values[(unsigned char)str[2]];
+      /*FALLTHROUGH*/
       case 2:
       case 1:
         hval += asso_values[(unsigned char)str[0]];
@@ -62,6 +94,9 @@ hash2 (str, len)
 
 #ifdef __GNUC__
 __inline
+#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 struct token_trans *
 is_ckey (str, len)
@@ -70,57 +105,81 @@ is_ckey (str, len)
 {
   static struct token_trans wordlist[] =
     {
+      {""}, {""}, {""},
+#line 16 "token2.tok"
+      {"for",		TK_FOR},
       {""}, {""},
+#line 22 "token2.tok"
+      {"return",		TK_RETURN},
+#line 18 "token2.tok"
       {"if",		TK_IF},
-      {""},
+#line 19 "token2.tok"
+      {"int",		TK_INT},
+#line 32 "token2.tok"
       {"void",		TK_VOID},
-      {"while",		TK_WHILE},
+#line 30 "token2.tok"
+      {"union",		TK_UNION},
+#line 27 "token2.tok"
+      {"struct",		TK_STRUCT},
+#line 29 "token2.tok"
+      {"typedef",	TK_TYPEDEF},
+#line 31 "token2.tok"
+      {"unsigned",	TK_UNSIGNED},
+#line 17 "token2.tok"
+      {"goto",		TK_GOTO},
+#line 15 "token2.tok"
+      {"float",		TK_FLOAT},
+#line 28 "token2.tok"
       {"switch",		TK_SWITCH},
       {""},
-      {"__LINE__",	TK_LINE},
-      {""}, {""},
-      {"static",		TK_STATIC},
-      {"do",		TK_DO},
-      {"__FILE__",	TK_FILE},
+#line 21 "token2.tok"
+      {"register",	TK_REGISTER},
+#line 5 "token2.tok"
       {"case",		TK_CASE},
+#line 23 "token2.tok"
+      {"short",		TK_SHORT},
+#line 24 "token2.tok"
+      {"signed",		TK_SIGNED},
+      {""},
+#line 36 "token2.tok"
+      {"__LINE__",	TK_LINE},
+#line 13 "token2.tok"
+      {"enum",		TK_ENUM},
+#line 7 "token2.tok"
       {"const",		TK_CONST},
+#line 14 "token2.tok"
+      {"extern",		TK_EXTERN},
+#line 10 "token2.tok"
+      {"do",		TK_DO},
+#line 8 "token2.tok"
+      {"continue",	TK_CONTINUE},
+#line 12 "token2.tok"
+      {"else",		TK_ELSE},
+#line 34 "token2.tok"
+      {"while",		TK_WHILE},
+#line 11 "token2.tok"
+      {"double",		TK_DOUBLE},
+#line 9 "token2.tok"
+      {"default",	TK_DEFAULT},
+#line 33 "token2.tok"
+      {"volatile",	TK_VOLATILE},
+#line 3 "token2.tok"
+      {"auto",		TK_AUTO},
+#line 4 "token2.tok"
+      {"break",		TK_BREAK},
+#line 25 "token2.tok"
       {"sizeof",		TK_SIZEOF},
       {""},
-      {"continue",	TK_CONTINUE},
-      {"char",		TK_CHAR},
-      {"short",		TK_SHORT},
-      {"struct",		TK_STRUCT},
-      {""}, {""},
-      {"else",		TK_ELSE},
-      {"union",		TK_UNION},
-      {""}, {""},
-      {"unsigned",	TK_UNSIGNED},
-      {""},
-      {"break",		TK_BREAK},
-      {"signed",		TK_SIGNED},
-      {""}, {""}, {""}, {""},
-      {"double",		TK_DOUBLE},
-      {"default",	TK_DEFAULT},
-      {"for",		TK_FOR},
-      {""},
-      {"float",		TK_FLOAT},
-      {""}, {""},
-      {"int",		TK_INT},
-      {"enum",		TK_ENUM},
-      {""}, {""},
-      {"typedef",	TK_TYPEDEF},
-      {"register",	TK_REGISTER},
-      {"auto",		TK_AUTO},
-      {""}, {""}, {""}, {""},
+#line 35 "token2.tok"
+      {"__FILE__",	TK_FILE},
+#line 20 "token2.tok"
       {"long",		TK_LONG},
-      {""}, {""}, {""},
-      {"volatile",	TK_VOLATILE},
+      {""},
+#line 26 "token2.tok"
+      {"static",		TK_STATIC},
       {""}, {""},
-      {"return",		TK_RETURN},
-      {""}, {""}, {""}, {""},
-      {"extern",		TK_EXTERN},
-      {""}, {""},
-      {"goto",		TK_GOTO}
+#line 6 "token2.tok"
+      {"char",		TK_CHAR}
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
@@ -131,7 +190,7 @@ is_ckey (str, len)
         {
           register const char *s = wordlist[key].name;
 
-          if (*str == *s && !strncmp (str + 1, s + 1, len - 1))
+          if (*str == *s && !strncmp (str + 1, s + 1, len - 1) && s[len] == '\0')
             return &wordlist[key];
         }
     }

--- a/elksemu/Makefile
+++ b/elksemu/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Default
 ifeq ($(CFLAGS),)
-CFLAGS=-O
+CFLAGS=-O $(DEFS)
 endif
 
 # Turn on elkemu's strace like facility.

--- a/elksemu/elks.c
+++ b/elksemu/elks.c
@@ -4,7 +4,8 @@
  *	VM86 is used to process all the 8086 mode code.
  *	We trap up to 386 mode for system call emulation and naughties. 
  */
- 
+
+#define _GNU_SOURCE  /* for clone */ 
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -13,18 +14,22 @@
 #include <stdarg.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <sched.h>
 #include <errno.h>
+#include <stdint.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <asm/ldt.h>
+#include <asm/ptrace-abi.h>
 #include "elks.h" 
 
-#ifdef __BCC__
-#define OLD_LIBC_VERSION
-#endif
-
-volatile struct vm86_struct elks_cpu;
-unsigned char *elks_base;	/* Paragraph aligned */
+volatile struct elks_cpu_s elks_cpu;
+unsigned char *elks_base, *elks_data_base;	/* Paragraph aligned */
+unsigned short brk_at = 0;
 
 #ifdef DEBUG
 #define dbprintf(x) db_printf x
@@ -32,14 +37,52 @@ unsigned char *elks_base;	/* Paragraph aligned */
 #define dbprintf(x) 
 #endif
 
+static int modify_ldt(int func, void *ptr, unsigned long bytes)
+{
+	return syscall(SYS_modify_ldt, func, ptr, bytes);
+}
+
 static void elks_init()
 {
-	elks_cpu.screen_bitmap=0;
-	elks_cpu.cpu_type = CPU_286;
-	/*
-	 *	All INT xx calls are trapped.
-	 */
-	memset((void *)&elks_cpu.int_revectored,0xFF, sizeof(elks_cpu.int_revectored));
+	uint64_t ldt[8192];
+	struct user_desc cs_desc, ds_desc;
+	memset(ldt, 0, sizeof ldt);
+	int cs_idx = 0, ds_idx, ldt_count = modify_ldt(0, ldt, sizeof ldt);
+	unsigned cs, ds;
+	if (ldt_count < 0)
+		ldt_count = 0;
+	while (cs_idx < ldt_count && ldt[cs_idx] != 0)
+		++cs_idx;
+	ds_idx = cs_idx + 1;
+	while (ds_idx < ldt_count && ldt[ds_idx] != 0)
+		++ds_idx;
+	if (cs_idx >= 8192 || ds_idx >= 8192)
+	{
+		fprintf(stderr, "No free LDT descriptors for text and data "
+				"segments\n");
+		exit(255);
+	}
+	elks_cpu.regs.xcs = cs = cs_idx * 8 + 7;
+	elks_cpu.regs.xds = elks_cpu.regs.xes = elks_cpu.regs.xss
+			  = ds = ds_idx * 8 + 7;
+	dbprintf(("LDT descriptor for text is %#x\n", cs));
+	dbprintf(("LDT descriptor for data is %#x\n", ds));
+	/* Try to place dummy descriptors in the LDT */
+	memset(&cs_desc, 0, sizeof cs_desc);
+	cs_desc.entry_number = cs_idx;
+	cs_desc.contents = MODIFY_LDT_CONTENTS_CODE;
+	cs_desc.useable = 1;
+	memset(&ds_desc, 0, sizeof ds_desc);
+	ds_desc.entry_number = ds_idx;
+	ds_desc.contents = MODIFY_LDT_CONTENTS_DATA;
+	ds_desc.useable = 1;
+	if (modify_ldt(1, &cs_desc, sizeof cs_desc) != 0
+	    || modify_ldt(1, &ds_desc, sizeof ds_desc) != 0)
+	{
+		fprintf(stderr, "Cannot allocate LDT descriptors for text "
+				"and data segments\n");
+		exit(255);
+	}
 }
 
 static void elks_take_interrupt(int arg)
@@ -55,14 +98,22 @@ static void elks_take_interrupt(int arg)
 		return;
 	}
 	
-	dbprintf(("syscall AX=%x BX=%x CX=%x DX=%x\n",
-		(unsigned short)elks_cpu.regs.eax,
-		(unsigned short)elks_cpu.regs.ebx,
-		(unsigned short)elks_cpu.regs.ecx,
-		(unsigned short)elks_cpu.regs.edx));
+	dbprintf(("syscall AX=%x BX=%x CX=%x DX=%x SP=%x "
+		  "stack=%x %x %x %x %x\n",
+		(unsigned short)elks_cpu.regs.xax,
+		(unsigned short)elks_cpu.regs.xbx,
+		(unsigned short)elks_cpu.regs.xcx,
+		(unsigned short)elks_cpu.regs.xdx,
+		(unsigned short)elks_cpu.regs.xsp,
+		ELKS_PEEK(unsigned short, elks_cpu.regs.xsp),
+		ELKS_PEEK(unsigned short, elks_cpu.regs.xsp + 2),
+		ELKS_PEEK(unsigned short, elks_cpu.regs.xsp + 4),
+		ELKS_PEEK(unsigned short, elks_cpu.regs.xsp + 6),
+		ELKS_PEEK(unsigned short, elks_cpu.regs.xsp + 8)));
 		
-	elks_cpu.regs.eax = elks_syscall();
-	dbprintf(("elks syscall returned %d\n", elks_cpu.regs.eax));
+	elks_cpu.regs.xax = elks_syscall();
+	dbprintf(("elks syscall returned %d\n",
+		  (int)(short)elks_cpu.regs.xax));
 	/* Finally return to vm86 state */
 }
 
@@ -72,7 +123,7 @@ static int load_elks(int fd)
 	/* Load the elks binary image and set it up in a suitable VM86 segment. Load CS and DS/SS
 	   according to image type. chmem is ignored we always use 64K segments */
 	struct elks_exec_hdr mh;
-	unsigned char *dsp;
+	struct user_desc cs_desc, ds_desc;
 	if(read(fd, &mh,sizeof(mh))!=sizeof(mh))
 		return -ENOEXEC;
 	if(mh.hlen!=EXEC_HEADER_SIZE)
@@ -83,88 +134,147 @@ static int load_elks(int fd)
 	fprintf(stderr,"Linux-86 binary - %lX. tseg=%ld dseg=%ld bss=%ld\n",
 		mh.type,mh.tseg,mh.dseg,mh.bseg);
 #endif
+	if (mh.tseg > 0xfffful || mh.dseg > 0xfffful
+	    || mh.bseg > 0xfffful - mh.dseg || mh.entry >= mh.tseg)
+	{
+		fprintf(stderr, "Bogus a.out headers\n");
+		exit(1);
+	}
 	if(read(fd,elks_base,mh.tseg)!=mh.tseg)
 		return -ENOEXEC;
 	if(mh.type==ELKS_COMBID)
-		dsp=elks_base+mh.tseg;
+		elks_data_base=elks_base+mh.tseg;
 	else
-		dsp=elks_base+65536;
-	if(read(fd,dsp,mh.dseg)!=mh.dseg)
+		elks_data_base=elks_base+65536;
+	if(read(fd,elks_data_base,mh.dseg)!=mh.dseg)
 		return -ENOEXEC;
-	memset(dsp+mh.dseg,0, mh.bseg);
+	memset(elks_data_base+mh.dseg,0, mh.bseg);
 	/*
-	 *	Load the VM86 registers
+	 *	Really set up the LDT descriptors
 	 */
 	 
 	if(mh.type==ELKS_COMBID)
-		dsp=elks_base;
-	elks_cpu.regs.ds=PARAGRAPH(dsp);
-	elks_cpu.regs.es=PARAGRAPH(dsp);
-	elks_cpu.regs.ss=PARAGRAPH(dsp);
-	elks_cpu.regs.esp=65536; 	/* Args stacked later */
-	elks_cpu.regs.cs=PARAGRAPH(elks_base);
-	elks_cpu.regs.eip=0;		/* Run from 0 */
-	
-	/*
-	 *	Loaded, check for sanity.
-	 */
-	if( dsp != ELKS_PTR(unsigned char, 0) )
+		elks_data_base=elks_base;
+	memset(&cs_desc, 0, sizeof cs_desc);
+	memset(&ds_desc, 0, sizeof ds_desc);
+	cs_desc.entry_number = elks_cpu.regs.xcs / 8;
+	cs_desc.base_addr = (uintptr_t)elks_base;
+	cs_desc.limit = mh.tseg - 1;
+	cs_desc.contents = MODIFY_LDT_CONTENTS_CODE;
+	cs_desc.seg_not_present = mh.tseg == 0;
+	ds_desc.entry_number = elks_cpu.regs.xss / 8;
+	ds_desc.base_addr = (uintptr_t)elks_data_base;
+	ds_desc.limit = 0xffff;
+	ds_desc.contents = MODIFY_LDT_CONTENTS_DATA;
+	if (mh.type == ELKS_COMBID)
+		ds_desc.seg_not_present = mh.tseg == 0
+					  && mh.dseg == 0 && mh.bseg == 0;
+	else
+		ds_desc.seg_not_present = mh.dseg == 0 && mh.bseg == 0;
+	if (modify_ldt(1, &cs_desc, sizeof cs_desc) != 0
+	    || modify_ldt(1, &ds_desc, sizeof ds_desc) != 0)
 	{
-	   printf("Error VM86 problem %lx!=%lx (Is DS > 16 bits ?)\n",
-	           (long)dsp, (long)ELKS_PTR(char, 0));
-	   exit(0);
+		fprintf(stderr, "Cannot set LDT descriptors for text and data "
+				"segments\n");
+		exit(255);
 	}
-
+	elks_cpu.regs.xsp = 0;	 	/* Args stacked later */
+	elks_cpu.regs.xip = mh.entry;	/* Run from entry point */
+	elks_cpu.child = 0;
+	if (mh.type == ELKS_COMBID)
+		brk_at = mh.tseg + mh.dseg + mh.bseg;
+	else
+		brk_at = mh.dseg + mh.bseg;
 	return 0;
 }
 
-#ifndef OLD_LIBC_VERSION
-  /*
-   *  recent versions of libc have changed the proto for vm86()
-   *  for now I'll just override ...
-   */
-#define OLD_SYS_vm86  113
-#define NEW_SYS_vm86  166
-
-static inline int vm86_mine(struct vm86_struct* v86)
+static int child_idle(void *dummy)
 {
-	int __res;
-	__asm__ __volatile__("int $0x80\n"
-	:"=a" (__res):"a" ((int)OLD_SYS_vm86), "b" ((int)v86));
-	return __res;
-} 
-#endif
+	for (;;)
+		raise(SIGSTOP);
+	return 0;
+}
+
+static int wait_for_child(void)
+{
+	pid_t child = elks_cpu.child, pid;
+	int status;
+	while ((pid = waitpid(child, &status, 0)) != child)
+	{
+		if (pid < 0)
+		{
+			fprintf(stderr, "waitpid failed\n");
+			exit(255);
+		}
+	}
+	return status;
+}
 
 void run_elks()
 {
 	/*
 	 *	Execute 8086 code for a while.
 	 */
-#ifndef OLD_LIBC_VERSION
-	int err=vm86_mine((struct vm86_struct*)&elks_cpu);
-#else
-	int err=vm86((struct vm86_struct*)&elks_cpu);
-#endif
-	switch(VM86_TYPE(err))
+	pid_t child = elks_cpu.child;
+	int status;
+	if (!child)
 	{
-		/*
-		 *	Signals are just re-starts of emulation (yes the
-		 *	handler might alter elks_cpu)
-		 */
-		case VM86_SIGNAL:
-			break;
-		case VM86_UNKNOWN:
-			fprintf(stderr, "VM86_UNKNOWN returned\n");
-			exit(1);
-		case VM86_INTx:
-			elks_take_interrupt(VM86_ARG(err));
-			break;
-		case VM86_STI:
-			fprintf(stderr, "VM86_STI returned\n");
-			break;	/* Shouldnt be seen */
-		default:
-			fprintf(stderr, "Unknown return value from vm86\n");
-			exit(1);
+		child = clone(child_idle, elks_data_base + 0x10000,
+			      CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_VM,
+			      NULL);
+		if (child <= 0)
+		{
+			fprintf(stderr, "clone call failed\n");
+			exit(255);
+		}
+		dbprintf(("Created child thread %ld\n", (long)child));
+		elks_cpu.child = child;
+		if (ptrace(PTRACE_ATTACH, child, NULL, NULL) != 0)
+		{
+			int err = errno;
+			fprintf(stderr, "ptrace(PTRACE_ATTACH ...) failed\n");
+			fprintf(stderr, "%s\n", strerror(errno));
+			exit(255);
+		}
+		wait_for_child();
+	}
+	if (ptrace(PTRACE_SETREGS, child, NULL, &elks_cpu.regs) != 0)
+	{
+		fprintf(stderr, "ptrace(PTRACE_SETREGS ...) failed\n");
+		exit(255);
+	}
+	if (ptrace(PTRACE_SYSEMU, child, NULL, NULL) != 0)
+	{
+		fprintf(stderr, "ptrace(PTRACE_SYSEMU ...) failed\n");
+		exit(255);
+	}
+	status = wait_for_child();
+	if (ptrace(PTRACE_GETREGS, child, NULL, &elks_cpu.regs) != 0)
+	{
+		fprintf(stderr, "ptrace(PTRACE_GETREGS ...) failed\n");
+		exit(255);
+	}
+	dbprintf(("%#lx:%#lx\n", elks_cpu.regs.xcs, elks_cpu.regs.xip));
+	if (WIFSIGNALED(status))
+		raise(WTERMSIG(status));
+	else if (WIFSTOPPED(status))
+	{
+		siginfo_t si;
+		if (WSTOPSIG(status) != SIGTRAP
+		  || ptrace(PTRACE_GETSIGINFO, child, NULL, &si) != 0
+		  || (si.si_code != SIGTRAP
+		      && si.si_code != (SIGTRAP | 0x80)))
+			raise(WSTOPSIG(status));
+		else
+		{	/* this is a syscall-stop */
+			elks_cpu.regs.xax = elks_cpu.regs.orig_xax;
+			elks_take_interrupt(0x80);
+		}
+	}
+	else if (!WIFCONTINUED(status))
+	{
+		fprintf(stderr, "Unknown return value from waitpid\n");
+		exit(255);
 	}
 }
 
@@ -182,12 +292,16 @@ void build_stack(char ** argv, char ** envp)
 	{
 	   argv_count++; argv_len += strlen(*p)+1;
 	}
+	if (argv_len % 2)
+		argv_len++;
 
 	/* How much space for envp */
 	for(p=envp; *p; p++)
 	{
 	   envp_count++; envp_len += strlen(*p)+1;
 	}
+	if (envp_len % 2)
+		envp_len++;
 
 	/* tot it all up */
 	stack_bytes = 2				/* argc */
@@ -197,16 +311,16 @@ void build_stack(char ** argv, char ** envp)
 		    + envp_len;
 
 	/* Allocate it */
-	elks_cpu.regs.esp -= stack_bytes;
+	elks_cpu.regs.xsp -= stack_bytes;
 
-/* Sanity check 
-	printf("Argv = (%d,%d), Envp=(%d,%d), stack=%d\n",
-	        argv_count, argv_len, envp_count, envp_len, stack_bytes);
-*/
+#ifdef DEBUG
+	fprintf(stderr, "Argv = (%d,%d), Envp=(%d,%d), stack=%d\n",
+		argv_count, argv_len, envp_count, envp_len, stack_bytes);
+#endif
 
 	/* Now copy in the strings */
-	pip=ELKS_PTR(unsigned short, elks_cpu.regs.esp);
-	pcp=elks_cpu.regs.esp+2*(1+argv_count+1+envp_count+1);
+	pip=ELKS_PTR(unsigned short, elks_cpu.regs.xsp);
+	pcp=elks_cpu.regs.xsp+2*(1+argv_count+1+envp_count+1);
 
 	*pip++ = argv_count;
 	for(p=argv; *p; p++)
@@ -232,6 +346,7 @@ main(int argc, char *argv[], char *envp[])
 	int fd;
 	struct stat st;
 	int ruid, euid, rgid, egid;
+	int pg_sz;
 
 	if(argc<=1)
 	{
@@ -265,28 +380,24 @@ main(int argc, char *argv[], char *envp[])
 	dbprintf(("ELKSEMU\n"));
 	elks_init();
 
+	pg_sz = getpagesize();
+	if (pg_sz < 0)
+	{
+		fprintf(stderr, "Cannot get system page size\n");
+		exit(255);
+	}
+
 	/* The Linux vm will deal with not allocating the unused pages */
-#if __AOUT__
-#if __GNUC__
-	/* GNU malloc will align to 4k with large chunks */
-	elks_base = malloc(0x20000);
-#else
-	/* But others won't */
-	elks_base = malloc(0x20000+4096);
-	elks_base = (void*) (((int)elks_base+4095) & -4096);
-#endif
-#else
-	/* For ELF first 128M is unmapped, it needs to be mapped manually */
-	elks_base = mmap((void*)0x10000, 0x20000,
+	elks_base = mmap(NULL, 0x20000 + pg_sz,
 	                  PROT_EXEC|PROT_READ|PROT_WRITE,
-			  MAP_ANON|MAP_PRIVATE|MAP_FIXED, 
-			  0, 0);
-#endif
-	if( (long)elks_base < 0 || (long)elks_base >= 0xE0000 )
+			  MAP_ANON|MAP_PRIVATE|MAP_32BIT, 
+			  -1, 0);
+	if( (intptr_t)elks_base < 0 || (uintptr_t)elks_base >= 0x100000000ull)
 	{
 		fprintf(stderr, "Elks memory is at an illegal address\n");
 		exit(255);
 	}
+	mprotect(elks_base + 0x20000, pg_sz, PROT_NONE);
 	
 	if(load_elks(fd) < 0)
 	{
@@ -318,5 +429,6 @@ static FILE * db_fd = 0;
   va_start(ptr, fmt);
   rv = vfprintf(db_fd,fmt,ptr);
   va_end(ptr);
+  fflush(db_fd);
 }
 #endif

--- a/elksemu/elks_signal.c
+++ b/elksemu/elks_signal.c
@@ -7,18 +7,17 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include "elks.h" 
 
 static int elks_sigtrap= -1;
 
 void sig_trap(int signo)
 {
-   elks_cpu.regs.esp -= 2;
-   ELKS_POKE(unsigned short, elks_cpu.regs.esp, signo);
-   elks_cpu.regs.esp -= 2;
-   ELKS_POKE(unsigned short, elks_cpu.regs.esp, elks_cpu.regs.eip);
-   elks_cpu.regs.eip = elks_sigtrap;
+   elks_cpu.regs.xsp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.xsp, signo);
+   elks_cpu.regs.xsp -= 2;
+   ELKS_POKE(unsigned short, elks_cpu.regs.xsp, elks_cpu.regs.xip);
+   elks_cpu.regs.xip = elks_sigtrap;
 }
 
 int elks_signal(int bx,int cx,int dx,int di,int si)

--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -696,7 +696,7 @@ elks_closedir(int bx)
 static int elks_sbrk(int bx,int cx,int dx,int di,int si)
 {
 	unsigned short old_brk_at = brk_at;
-	dbprintf(("sbrk(%d)\n",bx));
+	dbprintf(("sbrk(%d,0x%04x)\n",bx,cx));
 	if (bx % 2)
 	{
 		++bx;
@@ -705,7 +705,7 @@ static int elks_sbrk(int bx,int cx,int dx,int di,int si)
 	if (bx > 0) {
 		if (brk_at + bx < brk_at)
 		{
-			errno= 1;	/* Really return -1 */
+			errno= ENOMEM;
 			return -1;
 		}
 	}
@@ -713,17 +713,18 @@ static int elks_sbrk(int bx,int cx,int dx,int di,int si)
 	{
 		if (brk_at <= -bx || brk_at + bx >= elks_cpu.regs.xsp)
 		{
-			errno= 1;
+			errno= ENOMEM;
 			return -1;
 		}
 	}
 	if (brk_at >= elks_cpu.regs.xsp ^ brk_at + bx >= elks_cpu.regs.xsp)
 	{
-		errno = 1;
+		errno = ENOMEM;
 		return -1;
 	}
 	brk_at += bx;
-	return old_brk_at;
+	ELKS_POKE(int16_t, cx, old_brk_at);
+	return 0;
 }
 
 /****************************************************************************/

--- a/elksemu/elks_sys.c
+++ b/elksemu/elks_sys.c
@@ -9,7 +9,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include <sys/times.h>
 #include <utime.h>
 #include <termios.h>
@@ -22,6 +21,7 @@
 #include <sys/ioctl.h>
 #include <dirent.h>
 #include <sys/time.h>
+#include <linux/reboot.h>
 #include "elks.h" 
 
 #include "efile.h"
@@ -56,23 +56,9 @@ static int elks_closedir(int bx);
  
 static void squash_stat(struct stat *s, int bx)
 {
-#if 1	/* Can't use elks_stat, shot in the foot by alignment */
-
-	ELKS_POKE(short, bx+0, s->st_dev);
-	ELKS_POKE(short, bx+2, s->st_ino ^ (s->st_ino>>16));
-	ELKS_POKE(short, bx+4, s->st_mode);
-	ELKS_POKE(short, bx+6, s->st_nlink);
-	ELKS_POKE(short, bx+8, s->st_uid);
-	ELKS_POKE(short, bx+10, s->st_gid);
-	ELKS_POKE(short, bx+12, s->st_rdev);
-	ELKS_POKE(long, bx+14, s->st_size);
-	ELKS_POKE(long, bx+18, s->st_atime);
-	ELKS_POKE(long, bx+22, s->st_mtime);
-	ELKS_POKE(long, bx+26, s->st_ctime);
-#else
 	struct elks_stat * ms = ELKS_PTR(struct elks_stat, bx);
 	ms->est_dev=s->st_dev;
-	ms->est_inode=(unsigned short)s->st_ino;	/* Bits lost */
+	ms->est_inode=(uint16_t)s->st_ino;	/* Bits lost */
 	ms->est_mode=s->st_mode;
 	ms->est_nlink=s->st_nlink;
 	ms->est_uid=s->st_uid;
@@ -82,7 +68,6 @@ static void squash_stat(struct stat *s, int bx)
 	ms->est_atime=s->st_atime;
 	ms->est_mtime=s->st_mtime;
 	ms->est_ctime=s->st_ctime;
-#endif
 }
 
 /*
@@ -179,7 +164,7 @@ static int elks_close(int bx,int cx,int dx,int di,int si)
 static int elks_wait4(int bx,int cx,int dx,int di,int si)
 {
 	int status;
-	unsigned short *tp=ELKS_PTR(unsigned short, cx);
+	uint16_t *tp=ELKS_PTR(uint16_t, cx);
 	int r;
 	struct rusage use;
 
@@ -244,13 +229,9 @@ static int elks_chown(int bx,int cx,int dx,int di,int si)
 #define sys_brk elks_brk
 static int elks_brk(int bx,int cx,int dx,int di,int si)
 {
-	dbprintf(("brk(%d)\n",bx));	
-	if(bx>=elks_cpu.regs.esp)
-	{
-		errno= 1;	/* Really return -1 */
-		return -1;
-	}
-	return 0;		/* Can't return bx, 0xBAD1 is an error */
+	dbprintf(("brk(%d)\n",bx));
+	brk_at = bx;
+	return bx;
 }
 
 #define sys_stat elks_stat
@@ -278,12 +259,12 @@ static int elks_lstat(int bx,int cx,int dx,int di,int si)
 #define sys_lseek elks_lseek
 static int elks_lseek(int bx,int cx,int dx,int di,int si)
 {
-	long l=ELKS_PEEK(long, cx);
+	long l=ELKS_PEEK(int32_t, cx);
 	
 	dbprintf(("lseek(%d,%ld,%d)\n",bx,l,dx));
 	l = lseek(bx,l,dx);
 	if( l < 0 ) return -1;
-	ELKS_POKE(long, cx, l);
+	ELKS_POKE(int32_t, cx, l);
 	return 0;
 }
 
@@ -291,7 +272,7 @@ static int elks_lseek(int bx,int cx,int dx,int di,int si)
 static int elks_getpid(int bx,int cx,int dx,int di,int si)
 {
 	dbprintf(("getpid/getppid()\n"));
-	ELKS_POKE(unsigned short, bx, getppid());
+	ELKS_POKE(uint16_t, bx, getppid());
 	return getpid();
 }
 
@@ -306,7 +287,7 @@ static int elks_setuid(int bx,int cx,int dx,int di,int si)
 static int elks_getuid(int bx,int cx,int dx,int di,int si)
 {
 	dbprintf(("get[e]uid()\n"));
-	ELKS_POKE(unsigned short, bx, geteuid());
+	ELKS_POKE(uint16_t, bx, geteuid());
 	return getuid();
 }
 
@@ -338,7 +319,7 @@ static int elks_pause(int bx,int cx,int dx,int di,int si)
 #define sys_utime elks_utime
 static int elks_utime(int bx,int cx,int dx,int di,int si)
 {
-	unsigned long *up=ELKS_PTR(long, cx);
+	uint32_t *up=ELKS_PTR(uint32_t, cx);
 	struct utimbuf u;
 	u.actime=*up++;
 	u.modtime=*up;
@@ -370,7 +351,7 @@ static int elks_kill(int bx,int cx,int dx,int di,int si)
 #define sys_pipe elks_pipe
 static int elks_pipe(int bx,int cx,int dx,int di,int si)
 {
-	unsigned short *dp=ELKS_PTR(unsigned short, bx);
+	uint16_t *dp=ELKS_PTR(uint16_t, bx);
 	int p[2];
 	int err=pipe(p);
 	if(err==-1)
@@ -384,9 +365,9 @@ static int elks_pipe(int bx,int cx,int dx,int di,int si)
 static int elks_times(int bx,int cx,int dx,int di,int si)
 {
 	struct tms t;
-	long clock_ticks=times(&t);
-	long *tp=ELKS_PTR(long, bx);
-	long *clkt=ELKS_PTR(long, cx);
+	clock_t clock_ticks=times(&t);
+	int32_t *tp=ELKS_PTR(int32_t, bx);
+	int32_t *clkt=ELKS_PTR(int32_t, cx);
 	*tp++=t.tms_utime;
 	*tp++=t.tms_stime;
 	*tp++=t.tms_cutime;
@@ -404,7 +385,7 @@ static int elks_setgid(int bx,int cx,int dx,int di,int si)
 #define sys_getgid elks_getgid
 static int elks_getgid(int bx,int cx,int dx,int di,int si)
 {
-	ELKS_POKE(unsigned short, bx, getegid());
+	ELKS_POKE(uint16_t, bx, getegid());
 	return getgid();
 }
 
@@ -426,16 +407,16 @@ static int elks_execve(int bx,int cx,int dx,int di,int si)
 	int arg_ct,env_ct;
 	int ct;
 	char **argp, **envp;
-	unsigned short *bp;
+	uint16_t *bp;
 	unsigned char *base;
-	unsigned short *tmp;
+	uint16_t *tmp;
 	struct elks_exec_hdr mh;
 	int is_elks = 1;
 	
 	dbprintf(("exec(%s,%d,%d)\n",ELKS_PTR(char, bx), cx, dx));
 
 	base=ELKS_PTR(unsigned char, cx);
-	bp=ELKS_PTR(unsigned short, cx+2);
+	bp=ELKS_PTR(uint16_t, cx+2);
 	tmp=bp;
 
 	fd=open(ELKS_PTR(char, bx),O_RDONLY);
@@ -576,13 +557,13 @@ static int elks_gettimeofday(int bx,int cx,int dx,int di,int si)
 
 	if( ax == 0 && bx )
 	{
-	   ELKS_POKE(long, bx, tv.tv_sec);
-	   ELKS_POKE(long, bx+4, tv.tv_usec);
+	   ELKS_POKE(int32_t, bx, tv.tv_sec);
+	   ELKS_POKE(int32_t, bx+4, tv.tv_usec);
 	}
 	if( ax == 0 && cx )
 	{
-	   ELKS_POKE(short, cx, tz.tz_minuteswest);
-	   ELKS_POKE(short, cx+2, tz.tz_dsttime);
+	   ELKS_POKE(int16_t, cx, tz.tz_minuteswest);
+	   ELKS_POKE(int16_t, cx+2, tz.tz_dsttime);
 	}
 	return ax?-1:0;
 }
@@ -598,14 +579,14 @@ static int elks_settimeofday(int bx,int cx,int dx,int di,int si)
 	if( bx )
 	{
 	   pv = &tv;
-	   tv.tv_sec  = ELKS_PEEK(long, bx);
-	   tv.tv_usec = ELKS_PEEK(long, bx+4);
+	   tv.tv_sec  = ELKS_PEEK(int32_t, bx);
+	   tv.tv_usec = ELKS_PEEK(int32_t, bx+4);
 	}
 	if( cx )
 	{
 	   pz = &tz;
-	   tz.tz_minuteswest = ELKS_PEEK(short, cx);
-	   tz.tz_dsttime =     ELKS_PEEK(short, cx+2);
+	   tz.tz_minuteswest = ELKS_PEEK(int16_t, cx);
+	   tz.tz_dsttime =     ELKS_PEEK(int16_t, cx+2);
 	}
 
 	ax = settimeofday(pv, pz);
@@ -697,8 +678,8 @@ static int elks_readdir(int bx,int cx,int dx,int di,int si)
 	if( ent == 0 ) { if( errno ) { return -1; } else return 0; }
 
 	memcpy(ELKS_PTR(char, cx+10), ent->d_name, ent->d_reclen+1);
-	ELKS_POKE(long, cx, ent->d_ino);
-	ELKS_POKE(short, cx+8, ent->d_reclen);
+	ELKS_POKE(int32_t, cx, ent->d_ino);
+	ELKS_POKE(int16_t, cx+8, ent->d_reclen);
 	return dx;
 }
 
@@ -709,6 +690,40 @@ elks_closedir(int bx)
 	if( dirtab[bx] ) closedir(dirtab[bx]);
 	dirtab[bx] = 0;
 	return 0;
+}
+
+#define sys_sbrk elks_sbrk
+static int elks_sbrk(int bx,int cx,int dx,int di,int si)
+{
+	unsigned short old_brk_at = brk_at;
+	dbprintf(("sbrk(%d)\n",bx));
+	if (bx % 2)
+	{
+		++bx;
+		bx &= 0xFFFF;
+	}
+	if (bx > 0) {
+		if (brk_at + bx < brk_at)
+		{
+			errno= 1;	/* Really return -1 */
+			return -1;
+		}
+	}
+	else
+	{
+		if (brk_at <= -bx || brk_at + bx >= elks_cpu.regs.xsp)
+		{
+			errno= 1;
+			return -1;
+		}
+	}
+	if (brk_at >= elks_cpu.regs.xsp ^ brk_at + bx >= elks_cpu.regs.xsp)
+	{
+		errno = 1;
+		return -1;
+	}
+	brk_at += bx;
+	return old_brk_at;
 }
 
 /****************************************************************************/
@@ -742,7 +757,7 @@ static int elks_termios(int bx,int cx,int dx,int di,int si)
 static int elks_enosys(int bx,int cx,int dx,int di,int si)
 {
 	fprintf(stderr, "Function number %d called (%d,%d,%d)\n",
-	                 (int)(0xFFFF&elks_cpu.regs.eax),
+	                 (int)(0xFFFF&elks_cpu.regs.xax),
 			 bx, cx, dx);
 	errno = ENOSYS;
 	return -1;
@@ -761,14 +776,14 @@ static funcp jump_tbl[] = {
 int elks_syscall(void)
 {
 	int r, n;
-	int bx=elks_cpu.regs.ebx&0xFFFF;
-	int cx=elks_cpu.regs.ecx&0xFFFF;
-	int dx=elks_cpu.regs.edx&0xFFFF;
-	int di=elks_cpu.regs.edi&0xFFFF;
-	int si=elks_cpu.regs.esi&0xFFFF;
+	int bx=elks_cpu.regs.xbx&0xFFFF;
+	int cx=elks_cpu.regs.xcx&0xFFFF;
+	int dx=elks_cpu.regs.xdx&0xFFFF;
+	int di=elks_cpu.regs.xdi&0xFFFF;
+	int si=elks_cpu.regs.xsi&0xFFFF;
 	
 	errno=0;
-	n = (elks_cpu.regs.eax&0xFFFF);
+	n = (elks_cpu.regs.xax&0xFFFF);
 	if( n>= 0 && n< sizeof(jump_tbl)/sizeof(funcp) )
 	   r = (*(jump_tbl[n]))(bx, cx, dx, di, si);
 	else

--- a/elksemu/minix.c
+++ b/elksemu/minix.c
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/vm86.h>
 #include <sys/times.h>
 #include <utime.h>
 #include <termios.h>
@@ -45,9 +44,9 @@ minix_syscall()
    static char *nm[4] = {"?", "send", "receive", "sendrec"};
    char   tsks[10], syss[10];
 
-   int   sr  = (unsigned short) elks_cpu.regs.ecx;
-   int   tsk = (unsigned short) elks_cpu.regs.eax;
-   int   sys = ELKS_PEEK(short, (unsigned short) elks_cpu.regs.ebx + 2);
+   int   sr  = (unsigned short) elks_cpu.regs.xcx;
+   int   tsk = (unsigned short) elks_cpu.regs.xax;
+   int   sys = ELKS_PEEK(short, (unsigned short) elks_cpu.regs.xbx + 2);
 
    if (sr < 0 || sr > 3) sr = 0;
    switch(tsk)

--- a/ifdef.c
+++ b/ifdef.c
@@ -440,7 +440,7 @@ manifest_constant()
 /* Linux/unix */
 #ifdef __linux__
    save_name("__linux__", 'D');
-#ifdef __i386__
+#if defined __i386__ || defined __x86_64__
    save_name("__elksemu_works__", 'D');
 #endif
 #endif

--- a/libc/syscall/syscall.dev86
+++ b/libc/syscall/syscall.dev86
@@ -5,14 +5,17 @@
 # all three of those packages.
 #
 #	'.' = Ok, with comment
-#	'*' = Needs libc code (Prefix __)
+#	'*' = Needs libc code (Prefix _)
 #	'-' = Obsolete/not required
 #	'@' = May be required later
 #	'=' = Depends on stated config variable
+#	'!' = Last argument is optional in libc routine (i.e. variadic routine)
 #
 #	An initial plus on the call number specifies that this call is
 #	implemented in the kernel.
 #
+# Package versions are matched.
+# Elks version          - 0.3.0
 #
 # Name		No	Args	Flag, comment
 #
@@ -20,7 +23,7 @@ exit		+1	1	* c exit does stdio, _exit in crt0
 fork		+2	0	 
 read		+3	3	 
 write		+4	3	 
-open		+5	3	 
+open		+5	3	!
 close		+6	1	 
 wait4		+7	4
 creat		8	0	- Not needed alias for open
@@ -57,7 +60,7 @@ rename		+38	2
 mkdir		+39	2	 
 rmdir		+40	1	 
 dup		+41	1	. There is a fcntl lib function too.
-pipe		+42	1	 
+pipe		+42	1	= CONFIG_PIPE
 times		43	2	* 2nd arg is pointer for long ret val.
 profil		44	4	@
 dup2		+45	2
@@ -65,11 +68,11 @@ setgid		+46	1
 getgid		47	1	* this gets both gid and egid
 signal		+48	2	* have put the despatch table in user space.
 getinfo		49	1	@ possible? gets pid,ppid,uid,euid etc
-fcntl		+50	3	 
+fcntl		+50	3	!
 acct		51	1	@ Accounting to named file (off if null)
 phys		52	3	- Replaced by mmap()
 lock		53	1	@ Prevent swapping for this proc if flg!=0
-ioctl		+54	3	. make this and fcntl the same ?
+ioctl		+54	3	! make this and fcntl the same ?
 reboot		+55	3	. the magic number is 0xfee1,0xdead,...
 mpx		56	2	- Replaced by fifos and select.
 lstat		+57	2
@@ -78,18 +81,22 @@ readlink	+59	3
 umask		+60	1	 
 settimeofday	+61	2
 gettimeofday	+62	2
-select          +63     5	. 5 paramaters is possible
+select		+63	5	. 5 paramaters is possible
 readdir		+64	3	*
 insmod		65	1	- Removed support for modules
 fchown		+66	3
-dlload		+67	2
+dlload		+67	2	- Removed support for dynamic libraries
 setsid		+68	0
-socket		+69	3
-bind		+70	3
-listen		+71	2
-accept		+72	3
-connect		+73	3
-knlvsn          +74     1	= CONFIG_SYS_VERSION
+sbrk        +69 2	* Legacy number from Linux
+knlvsn		+74	1	= CONFIG_SYS_VERSION
+#
+# From /usr/include/asm-generic/unistd.h
+#
+socket		+198	3	= CONFIG_SOCKET
+bind		+200	3	= CONFIG_SOCKET
+listen		+201	2	= CONFIG_SOCKET
+accept		+202	3	= CONFIG_SOCKET
+connect		+203	3	= CONFIG_SOCKET
 #
 # Name			No	Args	Flag&comment
 #


### PR DESCRIPTION
With these patches, `elksemu` can now work on Linux/x86-32 _and_ Linux/x86-64.

The original implementation uses the `vm86(`...`)` system call --- only available on 32-bit kernels --- to run ELKS programs in V86 mode.

I opt to instead run ELKS programs in 16-bit protected mode; this is supported by both 32-bit and 64-bit kernels.

Thank you!