### PR TITLE
[libc] update _signal syscall semantics, per ABI change in ELKS

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -77,7 +77,7 @@ clean:
 
 install_incl: transfer
 	install -d $(DISTINCL)/include
-	cp -LpR include/* $(DISTINCL)/include
+	cp -LpR include/* kinclude/* $(DISTINCL)/include
 	-chown -R $(USERID):$(GROUPID) $(DISTINCL)/include
 	-chmod -R ugo-x,u=rwX,og=rX $(DISTINCL)/include
 

--- a/libc/syscall/syscall.dev86
+++ b/libc/syscall/syscall.dev86
@@ -66,7 +66,9 @@ profil		44	4	@
 dup2		+45	2
 setgid		+46	1	 
 getgid		47	1	* this gets both gid and egid
-signal		+48	2	* have put the despatch table in user space.
+signal		+48	3	* 1) have put the despatch table in user space.
+#				  2) accepts _far_ pointer to despatching
+#				     signal handler, hence 3 words of args.
 getinfo		49	1	@ possible? gets pid,ppid,uid,euid etc
 fcntl		+50	3	!
 acct		51	1	@ Accounting to named file (off if null)


### PR DESCRIPTION
This follows the ABI change in ELKS at https://github.com/jbruchon/elks/pull/629 .